### PR TITLE
  Issue 136: Configurable file extensions

### DIFF
--- a/reflections/src/main/java/org/reflections/adapters/JavaReflectionAdapter.java
+++ b/reflections/src/main/java/org/reflections/adapters/JavaReflectionAdapter.java
@@ -125,6 +125,10 @@ public class JavaReflectionAdapter implements MetadataAdapter<Class, Field, Memb
         return names;
     }
 
+    public boolean acceptsInput(String file) {
+        return file.endsWith(".class");
+    }
+    
     //
     private List<String> getAnnotationNames(Annotation[] annotations) {
         List<String> names = new ArrayList<String>(annotations.length);

--- a/reflections/src/main/java/org/reflections/adapters/JavassistAdapter.java
+++ b/reflections/src/main/java/org/reflections/adapters/JavassistAdapter.java
@@ -142,6 +142,10 @@ public class JavassistAdapter implements MetadataAdapter<ClassFile, FieldInfo, M
         return Arrays.asList(cls.getInterfaces());
     }
 
+    public boolean acceptsInput(String file) {
+        return file.endsWith(".class");
+    }
+    
     //
     private List<String> getAnnotationNames(final AnnotationsAttribute... annotationsAttributes) {
         List<String> result = Lists.newArrayList();

--- a/reflections/src/main/java/org/reflections/adapters/MetadataAdapter.java
+++ b/reflections/src/main/java/org/reflections/adapters/MetadataAdapter.java
@@ -48,4 +48,7 @@ public interface MetadataAdapter<C,F,M> {
     String getMethodFullKey(C cls, M method);
 
     boolean isPublic(Object o);
+    
+    boolean acceptsInput(String file);
+    
 }

--- a/reflections/src/main/java/org/reflections/scanners/AbstractScanner.java
+++ b/reflections/src/main/java/org/reflections/scanners/AbstractScanner.java
@@ -21,7 +21,7 @@ public abstract class AbstractScanner implements Scanner {
 	private Predicate<String> resultFilter = Predicates.alwaysTrue(); //accept all by default
 
     public boolean acceptsInput(String file) {
-        return file.endsWith(".class"); //is a class file
+        return getMetadataAdapter().acceptsInput(file);
     }
 
     public Object scan(Vfs.File file, Object classObject) {


### PR DESCRIPTION
Allow new Adapters that can rely on other file types than ".class". An example for this is https://github.com/fuinorg/refmopp - It can parse".java" as well as ".class" files.
