### PR TITLE
Cannot get children because it is not a folder.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.reflections</groupId>
     <artifactId>reflections-parent</artifactId>
-    <version>0.9.9-RC1</version>
+    <version>0.9.9-RC2</version>
     <packaging>pom</packaging>
 
     <name>Reflections</name>

--- a/reflections-maven/pom.xml
+++ b/reflections-maven/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reflections</groupId>
         <artifactId>reflections-parent</artifactId>
-        <version>0.9.9-RC1</version>
+        <version>0.9.9-RC2</version>
     </parent>
 
     <artifactId>reflections-maven</artifactId>

--- a/reflections/pom.xml
+++ b/reflections/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reflections</groupId>
         <artifactId>reflections-parent</artifactId>
-        <version>0.9.9-RC1</version>
+        <version>0.9.9-RC2</version>
     </parent>
 
     <artifactId>reflections</artifactId>

--- a/reflections/src/main/java/org/reflections/vfs/CommonsVfs2UrlType.java
+++ b/reflections/src/main/java/org/reflections/vfs/CommonsVfs2UrlType.java
@@ -79,8 +79,11 @@ public interface CommonsVfs2UrlType {
 
             protected List<FileObject> listFiles(final FileObject file) {
                 try {
-                    FileObject[] files = file.getChildren();
-                    return files != null ? Lists.newArrayList(files) : new ArrayList<FileObject>();
+					FileObject[] files = null;
+					if (file.getType().hasChildren()) {
+						files = file.getChildren();
+					}
+					return files != null ? Lists.newArrayList(files) : new ArrayList<FileObject>(); 
                 } catch (FileSystemException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
Hi there,

I am using Tanukisoft JSW service wrapper and I get an exception that says: Cannot get children of wrapper-windows-x86-64.dll because it is not a folder. After debugging it I saw that CommonsVfs2UrlType:83 simply says file.getChildren() and in my case the DLL file is a file, not a folder. So I added an if-statement to check if it's a folder and only then get the children. Now it works perfectly.

Please review and merge.
Also once commons-vfs2 v.2.1 is out there will be a new method FileObject.isFolder() so maybe that will be a better way to check if it's a folder.
