### PR TITLE
Use the supplied classloaders when no base package is supplied

### DIFF
--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -110,7 +110,11 @@ public class ConfigurationBuilder implements Configuration {
         }
 
         if (builder.getUrls().isEmpty()) {
-            builder.addUrls(ClasspathHelper.forClassLoader()); //default urls getResources("")
+            if (classLoaders != null) {
+                builder.addUrls(ClasspathHelper.forClassLoader(classLoaders)); //default urls getResources("")
+            } else {
+                builder.addUrls(ClasspathHelper.forClassLoader()); //default urls getResources("")
+            }
         }
 
         builder.filterInputsBy(filter);


### PR DESCRIPTION
When no base package is specified, but classloaders are, then we should use the provided loaders, not the default ones.
