### PR TITLE
Fix inconsistency in unit tests related to testModel-reflections.xml

### DIFF
--- a/src/test/java/org/reflections/ReflectionsTest.java
+++ b/src/test/java/org/reflections/ReflectionsTest.java
@@ -214,7 +214,7 @@ public class ReflectionsTest {
 
     @Test
     public void testResourcesScanner() {
-        Predicate<String> filter = new FilterBuilder().include(".*\\.xml");
+        Predicate<String> filter = new FilterBuilder().include(".*\\.xml").exclude(".*testModel-reflections\\.xml");
         Reflections reflections = new Reflections(new ConfigurationBuilder()
                 .filterInputsBy(filter)
                 .setScanners(new ResourcesScanner())
@@ -224,8 +224,7 @@ public class ReflectionsTest {
         assertThat(resolved, are("META-INF/reflections/resource1-reflections.xml"));
 
         Set<String> resources = reflections.getStore().get(ResourcesScanner.class.getSimpleName()).keySet();
-        assertThat(resources, are("resource1-reflections.xml", "resource2-reflections.xml",
-                "testModel-reflections.xml"));
+        assertThat(resources, are("resource1-reflections.xml", "resource2-reflections.xml"));
     }
 
     @Test


### PR DESCRIPTION
The META-INF/reflections/testModel-reflections.xml file is created by ReflectionsCollectTest, and its presence was expected in ReflectionsTest.testResourcesScanner(). The assertion wasn't always satisfied, depending on the order of execution of tests.

Make testResourcesScanner() exclude testModel-reflections.xml from scanned resources and change the assertion not to expect the excluded file.

This fixes random build failures when compiling the tests.
