### PR TITLE
Websphere fix, see https://github.com/ronmamo/reflections/issues/22

### DIFF
--- a/src/main/java/org/reflections/util/ClasspathHelper.java
+++ b/src/main/java/org/reflections/util/ClasspathHelper.java
@@ -112,7 +112,9 @@ public abstract class ClasspathHelper {
                     if (index != -1) {
                         result.add(new URL(url.toExternalForm().substring(0, index)));
                     } else {
-                        result.add(url); //whatever
+						result.add(new URL(
+								url.getProtocol().replaceFirst("^wsjar", "jar"), url.getHost(), url.getFile())
+						); //whatever
                     }
                 }
             } catch (IOException e) {

--- a/src/test/java/org/reflections/MyTestModelStore.java
+++ b/src/test/java/org/reflections/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Fri Jun 13 17:34:35 IDT 2014]
+//generated using Reflections JavaCodeSerializer [Tue Nov 11 12:45:43 CET 2014]
 package org.reflections;
 
 public interface MyTestModelStore {


### PR DESCRIPTION
This was reported earlier, not sure why it was never merged. Anyway it's a quick and dirty but working fix for webshperes idiotic wsjar resources. Without it reflections tries to open the resource via vfs2 which then fails.
