### PR TITLE
Third and final fix for Websphere

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -213,11 +213,11 @@ public class Reflections {
                     scannedFiles.value = scan(url);
                 }
                 scannedUrls++;
-				if (log != null && log.isWarnEnabled()) {
+				if (log != null && log.isDebugEnabled()) {
 					
-					log.debug(format("Reflections scanned %s, containing %d file(s)",
-							url,
-							scannedFiles.value));
+					log.debug(format("Reflections scanned  %d file(s) from %s",
+							scannedFiles.value
+							,url));
 				}
 				
             } catch (ReflectionsException e) {

--- a/src/test/java/org/reflections/MyTestModelStore.java
+++ b/src/test/java/org/reflections/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Wed Nov 12 16:53:27 CET 2014]
+//generated using Reflections JavaCodeSerializer [Thu Nov 13 08:24:56 CET 2014]
 package org.reflections;
 
 public interface MyTestModelStore {


### PR DESCRIPTION
Basically Websphere has problems finding resource prefixes that do not end with a /

The version here is now working correctly when using forPackage and forResource.

It is also logging some warnings on websphere about its strange behaviour.
