### PR TITLE
Don't filter using path where slashs are replaced but dots

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -234,8 +234,9 @@ public class Reflections {
 
     public void scan(URL url) {
         for (final Vfs.File file : Vfs.fromURL(url).getFiles()) {
-            String input = file.getRelativePath().replace('/', '.');
-            if (configuration.getInputsFilter() == null || configuration.getInputsFilter().apply(input)) {
+            String relativePath = file.getRelativePath();
+            String input = relativePath.replace('/', '.');
+            if (configuration.getInputsFilter() == null || configuration.getInputsFilter().apply(relativePath)) {
                 Object classObject = null;
                 for (Scanner scanner : configuration.getScanners()) {
                     try {

--- a/src/main/java/org/reflections/util/FilterBuilder.java
+++ b/src/main/java/org/reflections/util/FilterBuilder.java
@@ -58,7 +58,7 @@ public class FilterBuilder implements Predicate<String> {
             for (Predicate<String> filter : chain) {
                 if (accept && filter instanceof Include) {continue;} //skip if this filter won't change
                 if (!accept && filter instanceof Exclude) {continue;}
-                accept = filter.apply(regex);
+                accept = filter.apply(regex.replace('/', '.'));
                 if (!accept && filter instanceof Exclude) {break;} //break on first exclusion
             }
         }


### PR DESCRIPTION
when using filterInputsBy it can cause issues. For example
com/github/example1/1.xml is replaced by com.github.example1.1.xml
so your filter for
com/gitjub/example1/*.xml is not working ...