### PR TITLE
Fixed premature return in FilterBuilder.includePackage(String...)

### DIFF
--- a/src/main/java/org/reflections/util/FilterBuilder.java
+++ b/src/main/java/org/reflections/util/FilterBuilder.java
@@ -42,7 +42,7 @@ public class FilterBuilder implements Predicate<String> {
     /** include packages of given prefixes */
     public FilterBuilder includePackage(final String... prefixes) {
         for (String prefix : prefixes) {
-            return add(new Include(prefix(prefix)));
+            add(new Include(prefix(prefix)));
         }
         return this;
     }

--- a/src/test/java/org/reflections/FilterBuilderTest.java
+++ b/src/test/java/org/reflections/FilterBuilderTest.java
@@ -28,6 +28,16 @@ public class FilterBuilderTest {
     }
 
     @Test
+    public void test_includePackageMultiple() {
+        FilterBuilder filter = new FilterBuilder().includePackage("org.reflections", "org.foo");
+        assertTrue(filter.apply("org.reflections.Reflections"));
+        assertTrue(filter.apply("org.reflections.foo.Reflections"));
+        assertTrue(filter.apply("org.foo.Reflections"));
+        assertTrue(filter.apply("org.foo.bar.Reflections"));
+        assertFalse(filter.apply("org.bar.Reflections"));
+    }
+
+    @Test
     public void test_includePackagebyClass() {
         FilterBuilder filter = new FilterBuilder().includePackage(Reflections.class);
         assertTrue(filter.apply("org.reflections.Reflections"));


### PR DESCRIPTION
FilterBuilder.includePackage(String...) was returning after adding the first package
passed in.  As a result, if the method was called with more than one package, only
the first would be added.  All others would be ignored.  This fix removes the errant
return statment in the for loop to ensure that all passed in packages will be added.