### PR TITLE
Replace annotations:2.0.1 with jsr305:3.0.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
 
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>2.0.1</version>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
The latter is new and smaller.

Alternatively, consider marking the existing dependency provided or optional ([that's safe](https://stackoverflow.com/questions/3567413/why-doesnt-a-missing-annotation-cause-a-classnotfoundexception-at-runtime)).