### PR TITLE
Just catch ReflectionsException

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -204,7 +204,7 @@ public class Reflections {
                     scan(url);
                 }
                 scannedUrls++;
-            } catch (ReflectionsException e) {
+            } catch (ReflectionsException | NullPointerException e) {
                 if (log != null && log.isWarnEnabled()) log.warn("could not create Vfs.Dir from url. ignoring the exception and continuing", e);
             }
         }

--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -249,7 +249,7 @@ public class Reflections {
                             if (scanner.acceptsInput(path) || scanner.acceptResult(fqn)) {
                                 classObject = scanner.scan(file, classObject);
                             }
-                        } catch (Exception e) {
+                        } catch (ReflectionsException e) {
                             if (log != null && log.isDebugEnabled())
                                 log.debug("could not scan file " + file.getRelativePath() + " in url " + url.toExternalForm() + " with scanner " + scanner.getClass().getSimpleName(), e.getMessage());
                         }


### PR DESCRIPTION
Just catch your own exceptions. I think only ReflectionsException are raised by the scanners/adapters. If something more severe is happening the exception has to be a wider scope. I my case the javaassit jar was not in the classpath.