### PR TITLE
Websphere adaptions in forPackage and forResource

### DIFF
--- a/src/main/java/org/reflections/util/ClasspathHelper.java
+++ b/src/main/java/org/reflections/util/ClasspathHelper.java
@@ -21,6 +21,16 @@ import java.util.jar.Manifest;
  * Helper methods for working with the classpath.
  */
 public abstract class ClasspathHelper {
+	
+    /**
+     * Is the classloader from IBM and thus the WebSphere platform?
+     *
+     * @param loader  the classloader
+     * @return  <tt>true</tt> if IBM classloader, <tt>false</tt> otherwise.
+     */
+    public static boolean isWebSphereClassLoader(ClassLoader loader) {
+        return loader != null ? loader.getClass().getName().startsWith("com.ibm") : false;
+    }
 
     /**
      * Gets the current thread context class loader.
@@ -78,6 +88,11 @@ public abstract class ClasspathHelper {
      * @return the collection of URLs, not null
      */
     public static Collection<URL> forPackage(String name, ClassLoader... classLoaders) {
+        if(isWebSphereClassLoader(classLoaders(classLoaders)[0])){
+            // inexplicable WAS returns only half of the jars when not adding / to a directory (package)
+            String filteredResourceName = resourceName(name);
+            return forResource(filteredResourceName.endsWith("/") ? filteredResourceName : filteredResourceName +"/", classLoaders);
+        }
         return forResource(resourceName(name), classLoaders);
     }
 
@@ -100,7 +115,22 @@ public abstract class ClasspathHelper {
         final ClassLoader[] loaders = classLoaders(classLoaders);
         for (ClassLoader classLoader : loaders) {
             try {
-                final Enumeration<URL> urls = classLoader.getResources(resourceName);
+                Enumeration<URL> urls = classLoader.getResources(resourceName);
+                if (!urls.hasMoreElements() && isWebSphereClassLoader(classLoader) && !resourceName.endsWith("/")) {
+                    // WebSphere can not load resources if the resource to load is a folder name, such as a packagename.
+                    // It is only able to find resources if they end with / in that case!
+                    if (Reflections.log != null) {
+                        Reflections.log.warn("Reflections did not find any resources on Websphere, appending a / to resource filter and trying again");
+					}
+                    urls = classLoader.getResources(resourceName + "/");
+                }else if(isWebSphereClassLoader(classLoader)){
+                    // If we did find resources it doesn't mean we found them all!
+                    // Inexplicable WAS returns only half of the jars when not adding a / to a directory.
+                    // But that's what happening, so it might be a good idea to at least log some debug about that WAS "bug/feature".
+                    if (Reflections.log != null && Reflections.log.isDebugEnabled()) {
+                        Reflections.log.debug("Reflections is running on Websphere, please ensure that you append a / if you want to restrict the search to a directory or package (via forRecource())");
+                    }
+                }
                 while (urls.hasMoreElements()) {
                     final URL url = urls.nextElement();
                     int index = url.toExternalForm().lastIndexOf(resourceName);

--- a/src/test/java/org/reflections/MyTestModelStore.java
+++ b/src/test/java/org/reflections/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Tue Nov 11 12:45:43 CET 2014]
+//generated using Reflections JavaCodeSerializer [Mon Jul 20 09:48:55 CEST 2015]
 package org.reflections;
 
 public interface MyTestModelStore {


### PR DESCRIPTION
This change is the bare minimum needed so that this library is usable on Websphere.

Hope this minimal change gets accepted this time.

Websphere is not able to find resources if you don't add / to it.
This is especially a problem when using forPackage as the Websphere Classloader will never find anything!
In case of forResource you might find something but it might be incomplete!