### PR TITLE
PR to address #70

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -218,6 +218,11 @@ public class Reflections {
 
         time = System.currentTimeMillis() - time;
 
+        //gracefully shutdown the parallel scanner executor service.
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+
         if (log != null) {
             int keys = 0;
             int values = 0;

--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.reflections.Configuration;
 import org.reflections.Reflections;
 import org.reflections.ReflectionsException;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * a fluent builder for {@link org.reflections.Configuration}, to be used for constructing a {@link org.reflections.Reflections} instance
@@ -243,10 +245,12 @@ public class ConfigurationBuilder implements Configuration {
         return useParallelExecutor(Runtime.getRuntime().availableProcessors());
     }
 
-    /** sets the executor service used for scanning to ThreadPoolExecutor with core size as the given availableProcessors parameter
+    /** sets the executor service used for scanning to ThreadPoolExecutor with core size as the given availableProcessors parameter.
+     * the executor service spawns daemon threads by default.
      * <p>default is ThreadPoolExecutor with a single core */
     public ConfigurationBuilder useParallelExecutor(final int availableProcessors) {
-        setExecutorService(Executors.newFixedThreadPool(availableProcessors));
+        ThreadFactory factory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat("org.reflections-scanner-%d").build();
+        setExecutorService(Executors.newFixedThreadPool(availableProcessors, factory));
         return this;
     }
 


### PR DESCRIPTION
* Changed `ConfigurationBuilder` to use a thread factory which spawns only daemon threads.
* Updated `Reflections` to gracefully stop/shutdown the parallel scanner executor pool