### PR TITLE
Make JSR305 annotations provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Inspired by https://github.com/OpenHFT/Koloboke/commit/9a66bbbf8021609414fdc410d2ecf6f22036b8d7 -- the JSR305 annotations are not actually needed at runtime, so can be `provided`. They're also LGPL licensed (http://findbugs.sourceforge.net/), which is hard to bundle with Apache licensed code. This makes sure assembly JARs wouldn't have to bundle them too.