### PR TITLE
PR to address #98 and rework withParametersAssignable

### DIFF
--- a/src/main/java/org/reflections/ReflectionUtils.java
+++ b/src/main/java/org/reflections/ReflectionUtils.java
@@ -36,6 +36,8 @@ import static org.reflections.util.Utils.isEmpty;
  *         <li>{@link #withParameters(Class[])}
  *         <li>{@link #withAnyParameterAnnotation(Class)}
  *         <li>{@link #withParametersAssignableTo(Class[])}
+ *         <li>{@link #withParametersAndSubclasses(Class[])}
+ *         <li>{@link #withParametersAndSuperclasses(Class[])}
  *         <li>{@link #withPrefix(String)}
  *         <li>{@link #withReturnType(Class)}
  *         <li>{@link #withType(Class)}
@@ -222,6 +224,15 @@ public abstract class ReflectionUtils {
 
     /** when member parameter types assignable to given {@code types} */
     public static Predicate<Member> withParametersAssignableTo(final Class... types) {
+        return withParametersAndSuperclasses(types);
+    }
+    
+    /**
+     * With parameters which are superclasses of the given {@code types}.
+     * 
+     * @param	types	the types to compare
+     */
+    public static Predicate<Member> withParametersAndSuperclasses(final Class... types) {
         return new Predicate<Member>() {
             public boolean apply(@Nullable Member input) {
                 if (input != null) {
@@ -229,6 +240,27 @@ public abstract class ReflectionUtils {
                     if (parameterTypes.length == types.length) {
                         for (int i = 0; i < parameterTypes.length; i++) {
                             if (!parameterTypes[i].isAssignableFrom(types[i]) ||
+                                    (parameterTypes[i] == Object.class && types[i] != Object.class)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+    
+    /** when member parameter types assignable to given {@code types} */
+    public static Predicate<Member> withParametersAndSubclasses(final Class... types) {
+        return new Predicate<Member>() {
+            public boolean apply(@Nullable Member input) {
+                if (input != null) {
+                    Class<?>[] parameterTypes = parameterTypes(input);
+                    if (parameterTypes.length == types.length) {
+                        for (int i = 0; i < parameterTypes.length; i++) {
+                            if (!types[i].isAssignableFrom(parameterTypes[i]) ||
                                     (parameterTypes[i] == Object.class && types[i] != Object.class)) {
                                 return false;
                             }

--- a/src/main/java/org/reflections/ReflectionUtils.java
+++ b/src/main/java/org/reflections/ReflectionUtils.java
@@ -228,7 +228,8 @@ public abstract class ReflectionUtils {
     }
     
     /**
-     * With parameters which are superclasses of the given {@code types}.
+     * With parameters which are the same as one of the {@code types} or are
+     * superclasses of them.
      * 
      * @param	types	the types to compare
      */
@@ -252,7 +253,12 @@ public abstract class ReflectionUtils {
         };
     }
     
-    /** when member parameter types assignable to given {@code types} */
+    /**
+     * With parameters which are the same as one of the {@code types} or are
+     * subclasses of them.
+     * 
+     * @param	types	the types to compare
+     */
     public static Predicate<Member> withParametersAndSubclasses(final Class... types) {
         return new Predicate<Member>() {
             public boolean apply(@Nullable Member input) {

--- a/src/test/java/org/reflections/ReflectionUtilsTest.java
+++ b/src/test/java/org/reflections/ReflectionUtilsTest.java
@@ -16,12 +16,15 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Collections2.transform;
 import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.hasItem;
 import static org.reflections.ReflectionUtils.*;
 import static org.reflections.ReflectionsTest.are;
+import static org.hamcrest.core.IsNot.not;
 
 /**
  * @author mamo
@@ -78,6 +81,28 @@ public class ReflectionUtilsTest {
         }
     }
 
+    @Test public void withSubclassParameters() throws Exception {
+        Set<Method> allMethods	= getAllMethods(Collections.class,
+        		withModifier(Modifier.STATIC),
+        		ReflectionUtils.withParametersAndSubclasses(Collection.class));
+        
+        assertThat(allMethods, hasItem(Collections.class.getMethod("enumeration", 
+        		Collection.class)));
+        assertThat(allMethods, hasItem(Collections.class.getMethod("sort", 
+        		List.class)));
+    }
+    
+    @Test public void withSuperclassParameters() throws Exception {
+        Set<Method> allMethods	= getAllMethods(Collections.class,
+        		withModifier(Modifier.STATIC),
+        		ReflectionUtils.withParametersAndSuperclasses(Collection.class));
+        
+        assertThat(allMethods, hasItem(Collections.class.getMethod("enumeration", 
+        		Collection.class)));
+        assertThat(allMethods, not(hasItem(Collections.class.getMethod("sort", 
+        		List.class))));
+    }
+    
     @Test public void withReturn() throws Exception {
         Set<Method> returnMember = getAllMethods(Class.class, withReturnTypeAssignableTo(Member.class));
         Set<Method> returnsAssignableToMember = getAllMethods(Class.class, withReturnType(Method.class));


### PR DESCRIPTION
Split `withParametersAssignable` into 
- `withParameterAndSubclasses` which finds methods with parameters matching a class and any of its subclasses (this replicates pre-v0.9.9 behaviour) 
- `withParameterAndSuperclasses` which locates superclasses (this replicates the post-v0.9.9 behaviour).
