### PR TITLE
Better separation of logger implementation.

### DIFF
--- a/src/main/java/org/reflections/ReflectionUtils.java
+++ b/src/main/java/org/reflections/ReflectionUtils.java
@@ -379,11 +379,9 @@ public abstract class ReflectionUtils {
                 }
             }
 
-            if (Reflections.log != null) {
-                for (ReflectionsException reflectionsException : reflectionsExceptions) {
-                    Reflections.log.warn("could not get type for name " + typeName + " from any class loader",
-                            reflectionsException);
-                }
+            for (ReflectionsException reflectionsException : reflectionsExceptions) {
+                Reflections.log.warn("could not get type for name " + typeName + " from any class loader",
+                        reflectionsException);
             }
 
             return null;

--- a/src/main/java/org/reflections/log/Logger.java
+++ b/src/main/java/org/reflections/log/Logger.java
@@ -1,0 +1,15 @@
+package org.reflections.log;
+
+public interface Logger {
+
+    void debug(String string, Throwable e);
+    void warn(String string, Throwable e);
+    void error(String string, Throwable e);
+
+    void debug(String string);
+    void info(String string);
+    void warn(String string);
+
+    boolean isDebugEnabled();
+    boolean isWarnEnabled();
+}

--- a/src/main/java/org/reflections/log/NullLogger.java
+++ b/src/main/java/org/reflections/log/NullLogger.java
@@ -1,0 +1,37 @@
+package org.reflections.log;
+
+public class NullLogger implements Logger {
+    @Override
+    public void debug(String string, Throwable e) {
+    }
+
+    @Override
+    public void warn(String string, Throwable e) {
+    }
+
+    @Override
+    public void error(String string, Throwable e) {
+    }
+
+    @Override
+    public void debug(String string) {
+    }
+
+    @Override
+    public void info(String string) {
+    }
+
+    @Override
+    public void warn(String string) {
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/org/reflections/log/Slf4jLogger.java
+++ b/src/main/java/org/reflections/log/Slf4jLogger.java
@@ -1,0 +1,52 @@
+package org.reflections.log;
+
+import org.slf4j.LoggerFactory;
+
+public class Slf4jLogger implements Logger {
+    private org.slf4j.Logger logger;
+
+    public Slf4jLogger(Class<?> aClass) {
+        this.logger =  LoggerFactory.getLogger(aClass);
+    }
+
+    @Override
+    public void debug(String string, Throwable e) {
+        logger.debug(string, e);
+    }
+
+    @Override
+    public void warn(String string, Throwable e) {
+        logger.warn(string, e);
+    }
+
+    @Override
+    public void error(String string, Throwable e) {
+        logger.error(string, e);
+    }
+
+    @Override
+    public void debug(String string) {
+        logger.debug(string);
+    }
+
+    @Override
+    public void info(String string) {
+        logger.info(string);
+    }
+
+    @Override
+    public void warn(String string) {
+        logger.warn(string);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+}

--- a/src/main/java/org/reflections/serializers/JavaCodeSerializer.java
+++ b/src/main/java/org/reflections/serializers/JavaCodeSerializer.java
@@ -119,7 +119,7 @@ public class JavaCodeSerializer implements Serializer {
 
     public String toString(Reflections reflections) {
         if (reflections.getStore().get(TypeElementsScanner.class.getSimpleName()).isEmpty()) {
-            if (log != null) log.warn("JavaCodeSerializer needs TypeElementsScanner configured");
+            log.warn("JavaCodeSerializer needs TypeElementsScanner configured");
         }
 
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/reflections/util/ClasspathHelper.java
+++ b/src/main/java/org/reflections/util/ClasspathHelper.java
@@ -109,9 +109,7 @@ public abstract class ClasspathHelper {
                     }
                 }
             } catch (IOException e) {
-                if (Reflections.log != null) {
-                    Reflections.log.error("error getting resources for " + resourceName, e);
-                }
+                Reflections.log.error("error getting resources for " + resourceName, e);
             }
         }
         return distinctUrls(result);
@@ -138,9 +136,7 @@ public abstract class ClasspathHelper {
                     return new URL(normalizedUrl);
                 }
             } catch (MalformedURLException e) {
-                if (Reflections.log != null) {
-                    Reflections.log.warn("Could not get URL", e);
-                }
+                Reflections.log.warn("Could not get URL", e);
             }
         }
         return null;
@@ -207,9 +203,7 @@ public abstract class ClasspathHelper {
                 try {
                     urls.add(new File(path).toURI().toURL());
                 } catch (Exception e) {
-                    if (Reflections.log != null) {
-                        Reflections.log.warn("Could not get URL", e);
-                    }
+                    Reflections.log.warn("Could not get URL", e);
                 }
             }
         }

--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -109,7 +109,7 @@ public class ConfigurationBuilder implements Configuration {
             else if (param instanceof ClassLoader) { /* already taken care */ }
             else if (param instanceof Predicate) { filter.add((Predicate<String>) param); }
             else if (param instanceof ExecutorService) { builder.setExecutorService((ExecutorService) param); }
-            else if (Reflections.log != null) { throw new ReflectionsException("could not use param " + param); }
+            else { throw new ReflectionsException("could not use param " + param); }
         }
 
         if (builder.getUrls().isEmpty()) {
@@ -197,8 +197,7 @@ public class ConfigurationBuilder implements Configuration {
             try {
                 return (metadataAdapter = new JavassistAdapter());
             } catch (Throwable e) {
-                if (Reflections.log != null)
-                    Reflections.log.warn("could not create JavassistAdapter, using JavaReflectionAdapter", e);
+                Reflections.log.warn("could not create JavassistAdapter, using JavaReflectionAdapter", e);
                 return (metadataAdapter = new JavaReflectionAdapter());
             }
         }

--- a/src/main/java/org/reflections/util/Utils.java
+++ b/src/main/java/org/reflections/util/Utils.java
@@ -4,8 +4,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import org.reflections.Reflections;
 import org.reflections.ReflectionsException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.reflections.log.Logger;
+import org.reflections.log.NullLogger;
+import org.reflections.log.Slf4jLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -140,19 +141,24 @@ public abstract class Utils {
     }
 
     public static void close(InputStream closeable) {
-        try { if (closeable != null) closeable.close(); }
-        catch (IOException e) {
-            if (Reflections.log != null) {
-                Reflections.log.warn("Could not close InputStream", e);
-            }
+        try {
+            if (closeable != null)
+                closeable.close();
+        } catch (IOException e) {
+            Reflections.log.warn("Could not close InputStream", e);
         }
     }
 
     @Nullable
     public static Logger findLogger(Class<?> aClass) {
+        Logger logger = trySlf4j(aClass);
+        return logger != null ? logger : new NullLogger();
+    }
+
+    private static Logger trySlf4j(Class<?> aClass) {
         try {
             Class.forName("org.slf4j.impl.StaticLoggerBinder");
-            return LoggerFactory.getLogger(aClass);
+            return new Slf4jLogger(aClass); 
         } catch (Throwable e) {
             return null;
         }

--- a/src/main/java/org/reflections/vfs/UrlTypeVFS.java
+++ b/src/main/java/org/reflections/vfs/UrlTypeVFS.java
@@ -38,15 +38,11 @@ public class UrlTypeVFS implements UrlType {
             URL adaptedUrl = adaptURL(url);
             return new ZipDir(new JarFile(adaptedUrl.getFile()));
         } catch (Exception e) {
-            if (Reflections.log != null) {
-                Reflections.log.warn("Could not get URL", e);
-            }
+            Reflections.log.warn("Could not get URL", e);
             try {
                 return new ZipDir(new JarFile(url.getFile()));
             } catch (IOException e1) {
-                if (Reflections.log != null) {
-                    Reflections.log.warn("Could not get URL", e1);
-                }
+                Reflections.log.warn("Could not get URL", e1);
             }
         }
         return null;

--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -100,9 +100,7 @@ public abstract class Vfs {
                     if (dir != null) return dir;
                 }
             } catch (Throwable e) {
-                if (Reflections.log != null) {
-                    Reflections.log.warn("could not create Dir using " + type + " from url " + url.toExternalForm() + ". skipping.", e);
-                }
+                Reflections.log.warn("could not create Dir using " + type + " from url " + url.toExternalForm() + ". skipping.", e);
             }
         }
 
@@ -147,9 +145,7 @@ public abstract class Vfs {
                             }
                         }, filePredicate));
             } catch (Throwable e) {
-                if (Reflections.log != null) {
-                    Reflections.log.error("could not findFiles for url. continuing. [" + url + "]", e);
-                }
+                Reflections.log.error("could not findFiles for url. continuing. [" + url + "]", e);
             }
         }
 

--- a/src/main/java/org/reflections/vfs/ZipDir.java
+++ b/src/main/java/org/reflections/vfs/ZipDir.java
@@ -43,9 +43,7 @@ public class ZipDir implements Vfs.Dir {
 
     public void close() {
         try { jarFile.close(); } catch (IOException e) {
-            if (Reflections.log != null) {
-                Reflections.log.warn("Could not close JarFile", e);
-            }
+            Reflections.log.warn("Could not close JarFile", e);
         }
     }
 


### PR DESCRIPTION
This change better separates Reflections from actual logging implementation. In enables serialization to work properly on Reflections.class in cases when slf4j is not present in the classpath. Another consequence is that by providing NullLogger, it's possible to always have Logger instantiated and, therefore, get rid of "if (Reflections.log != null)" checks.