### PR TITLE
add support for .war files scanning

### DIFF
--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -180,6 +180,7 @@ public abstract class Vfs {
             if (path.startsWith("wsjar:")) path = path.substring("wsjar:".length());
             if (path.startsWith("file:")) path = path.substring("file:".length());
             if (path.contains(".jar!")) path = path.substring(0, path.indexOf(".jar!") + ".jar".length());
+            if (path.contains(".war!")) path = path.substring(0, path.indexOf(".war!") + ".war".length());
             if ((file = new java.io.File(path)).exists()) return file;
 
             path = path.replace("%20", " ");


### PR DESCRIPTION
There was a case with a web app deployed to WLC where the library could not find classes, it fixed the issue.
