### PR TITLE
Make enhancements to search for member usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.reflections</groupId>
     <artifactId>reflections</artifactId>
-    <version>0.9.11-SNAPSHOT</version>
+    <version>0.9.12-SNAPSHOT</version>
     <packaging>${packaging.type}</packaging>
 
     <name>Reflections</name>
@@ -56,7 +56,7 @@
         <packaging.type>jar</packaging.type>
         <guava.version>19.0</guava.version>
         <javassist.version>3.20.0-GA</javassist.version>
-        <jdk.version>1.7</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 

--- a/src/test/java/org/reflections/BridgedMethodUsageTest.java
+++ b/src/test/java/org/reflections/BridgedMethodUsageTest.java
@@ -1,0 +1,40 @@
+package org.reflections;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.reflections.scanners.MemberUsageScanner;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.scanners.MethodParameterScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+
+/**
+ * Unit test for bridged method
+ */
+public class BridgedMethodUsageTest {
+
+	@Test
+	public void testGetMethodUsageInAnonymousClass()
+			throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+		Reflections r = new Reflections("org.reflections", new MethodAnnotationsScanner(), new SubTypesScanner(),
+				new MethodParameterScanner(), new TypeAnnotationsScanner(), new MemberUsageScanner());
+		Class<?> target = Class.forName("org.reflections.scanners.MemberUsageScanner");
+		Method[] methods = target.getDeclaredMethods();
+		for (Method m : methods) {
+			System.out.println(m.toGenericString());
+		}
+		Method outerMethod = target.getDeclaredMethod("put", String.class, Integer.TYPE, String.class);
+		Set<Member> set = r.getMethodUsage(outerMethod);
+		System.out.println("# caller: " + set.size());
+		Assert.assertEquals(1, set.size());
+		for (Member m : set) {
+			System.out.println("caller: " + m.getDeclaringClass().getName() + "." + m.getName());
+			Assert.assertEquals("org.reflections.scanners.MemberUsageScanner.scanMember",
+					m.getDeclaringClass().getName() + "." + m.getName());
+		}
+	}
+}


### PR DESCRIPTION
Take into account the situations where bridged method or synthetic method are utilized in class files. In that case, the original method will be found, but it may come with some
degree of performance penalty.