### PR TITLE
Extract class names when methods have spaces

### DIFF
--- a/src/main/java/org/reflections/util/Utils.java
+++ b/src/main/java/org/reflections/util/Utils.java
@@ -65,7 +65,7 @@ public abstract class Utils {
         String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
 
         int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"));
-        String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
+        String className = memberKey.substring(0, p1);
         String memberName = memberKey.substring(p1 + 1);
 
         Class<?>[] parameterTypes = null;


### PR DESCRIPTION
This change makes it possible to extract class and method name when method name has spaces (Ex: Methods in Kotlin Class)