### PR TITLE
Reduce Maven warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
         <guava.version>20.0</guava.version>
         <javassist.version>3.21.0-GA</javassist.version>
         <jdk.version>1.7</jdk.version>
+        <maven.compiler.source>${jdk.version}</maven.compiler.source>
+        <maven.compiler.target>${jdk.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
@@ -235,17 +238,4 @@
             </build>
         </profile>
     </profiles>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>


### PR DESCRIPTION
Have reduced the following Maven warnings:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.reflections:reflections:jar:0.9.12-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 241, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This one is caused by missing `<version>` in `maven-compiler-plugin` declaration.
There are two ways of fixing this: either to specify the version in the plugin declaration or to specify properties with the values required, since all you need is to specify java version.
Picked latter option, since it requires less xml and removes the requirement to update the plugin version from time to time, details are here: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html

Second warning is 

`[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!`

Fixed with `project.build.sourceEncoding` setting, more details are here: https://maven.apache.org/general.html#encoding-warning 
https://maven.apache.org/plugins/maven-resources-plugin/examples/encoding.html