### PR TITLE
Fix potential NPEs in reflections.

### DIFF
--- a/src/main/java/org/reflections/adapters/JavaReflectionAdapter.java
+++ b/src/main/java/org/reflections/adapters/JavaReflectionAdapter.java
@@ -102,9 +102,14 @@ public class JavaReflectionAdapter implements MetadataAdapter<Class, Field, Memb
     }
 
     public boolean isPublic(Object o) {
-        Integer mod =
-                o instanceof Class ? ((Class) o).getModifiers() :
-                o instanceof Member ? ((Member) o).getModifiers() : null;
+        Integer mod;
+        if (o instanceof Class) {
+            mod = ((Class) o).getModifiers();
+        } else if (o instanceof Member) {
+            mod = ((Member) o).getModifiers();
+        } else {
+          mod = null;
+        }
 
         return mod != null && Modifier.isPublic(mod);
     }

--- a/src/main/java/org/reflections/adapters/JavassistAdapter.java
+++ b/src/main/java/org/reflections/adapters/JavassistAdapter.java
@@ -121,10 +121,16 @@ public class JavassistAdapter implements MetadataAdapter<ClassFile, FieldInfo, M
     }
 
     public boolean isPublic(Object o) {
-        Integer accessFlags =
-                o instanceof ClassFile ? ((ClassFile) o).getAccessFlags() :
-                o instanceof FieldInfo ? ((FieldInfo) o).getAccessFlags() :
-                o instanceof MethodInfo ? ((MethodInfo) o).getAccessFlags() : null;
+        Integer accessFlags;
+        if (o instanceof ClassFile) {
+            accessFlags = ((ClassFile) o).getAccessFlags();
+        } else if (o instanceof FieldInfo) {
+            accessFlags = ((FieldInfo) o).getAccessFlags();
+        } else if (o instanceof MethodInfo) {
+            accessFlags = ((MethodInfo) o).getAccessFlags();
+        } else {
+            accessFlags = null;
+        }
 
         return accessFlags != null && AccessFlag.isPublic(accessFlags);
     }


### PR DESCRIPTION
The rules of numerical conditional expression evaluation are such that a primitive 2nd operand forces the 3rd operand to be unboxed. This means that if o is neither a Class nor a Member, the null will be unboxed.