### PR TITLE
Log ReflectionsException as warning during parallel scanning

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.sql.Ref;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;

--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.sql.Ref;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -214,7 +215,15 @@ public class Reflections {
         //todo use CompletionService
         if (executorService != null) {
             for (Future future : futures) {
-                try { future.get(); } catch (Exception e) { throw new RuntimeException(e); }
+                try {
+                    future.get();
+                } catch (ReflectionsException e) {
+                    if (log != null) {
+                        log.warn("could not create Vfs.Dir from url. ignoring the exception and continuing", e);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
 

--- a/src/test/java/org/reflections/MyTestModelStore.java
+++ b/src/test/java/org/reflections/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Tue Nov 11 12:45:43 CET 2014]
+//generated using Reflections JavaCodeSerializer [Tue Feb 13 12:00:21 PST 2018]
 package org.reflections;
 
 public interface MyTestModelStore {

--- a/src/test/java/org/reflections/MyTestModelStore.java
+++ b/src/test/java/org/reflections/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Tue Feb 13 12:00:21 PST 2018]
+//generated using Reflections JavaCodeSerializer [Tue Nov 11 12:45:43 CET 2014]
 package org.reflections;
 
 public interface MyTestModelStore {


### PR DESCRIPTION
This change ensures that parallel scanning does not propagate a ReflectionsException as a RuntimeException, similar to the single-threaded logic.