### PR TITLE
Extend Vfs.DefaultUrlTypes

### DIFF
--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -204,6 +204,7 @@ public abstract class Vfs {
      * <p>jarFile - creates a {@link org.reflections.vfs.ZipDir} over jar file
      * <p>jarUrl - creates a {@link org.reflections.vfs.ZipDir} over a jar url (contains ".jar!/" in it's name), using Java's {@link JarURLConnection}
      * <p>directory - creates a {@link org.reflections.vfs.SystemDir} over a file system directory
+     * <p>dockerExecutable - creates a {@link org.reflections.vfs.ZipDir} over a docker executabel, that is basically a jar or a zipfile, but has no filename extension
      * <p>jboss vfs - for protocols vfs, using jboss vfs (should be provided in classpath)
      * <p>jboss vfsfile - creates a {@link UrlTypeVFS} for protocols vfszip and vfsfile.
      * <p>bundle - for bundle protocol, using eclipse FileLocator (should be provided in classpath)
@@ -256,10 +257,14 @@ public abstract class Vfs {
 
         dockerExecutable {
             @Override
-            public boolean matches(final URL url) throws Exception {
+            public boolean matches(final URL url) {
                 if (url.getProtocol().equals("file") && !hasJarFileInPath(url)) {
-                    ZipDir zipDir = getZipDir(url);
-                    return zipDir.getFiles().iterator().hasNext();
+                    try {
+                        ZipDir zipDir = getZipDir(url);
+                        return zipDir.getFiles().iterator().hasNext();
+                    } catch (Throwable e) {
+                        Reflections.log.debug("Cannot extract given url " + url, e);
+                    }
                 }
                 return false;
             }

--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -216,7 +216,7 @@ public abstract class Vfs {
             }
 
             public Dir createDir(final URL url) throws Exception {
-                return new ZipDir(new JarFile(getFile(url)));
+                return getZipDir(url);
             }
         },
 
@@ -251,6 +251,22 @@ public abstract class Vfs {
 
             public Dir createDir(final URL url) throws Exception {
                 return new SystemDir(getFile(url));
+            }
+        },
+
+        dockerExecutable {
+            @Override
+            public boolean matches(final URL url) throws Exception {
+                if (url.getProtocol().equals("file") && !hasJarFileInPath(url)) {
+                    ZipDir zipDir = getZipDir(url);
+                    return zipDir.getFiles().iterator().hasNext();
+                }
+                return false;
+            }
+
+            @Override
+            public Dir createDir(final URL url) throws Exception {
+                return getZipDir(url);
             }
         },
 
@@ -299,6 +315,10 @@ public abstract class Vfs {
             public Dir createDir(final URL url) throws Exception {
                 return new JarInputDir(url);
             }
+        };
+
+        private static ZipDir getZipDir(final URL url) throws IOException {
+            return new ZipDir(new JarFile(getFile(url)));
         }
     }
 }


### PR DESCRIPTION
Had some trouble extracting a docker executable which is basically a jar or a zipfile but non of the given _DefaultUrlTypes_ matched. So I've added a new _UrlType_ for the usecase that such an executable is on the classpath. 