### PR TITLE
Updated guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </distributionManagement>
 
     <properties>
-        <guava.version>20.0</guava.version>
+        <guava.version>25.0-android</guava.version>
         <javassist.version>3.21.0-GA</javassist.version>
         <jdk.version>1.7</jdk.version>
         <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
Using 25.0-android as proposed by Google to keep Java 7 support. Fixes
#222