### PR TITLE
Add support for classfile to Vfs to allow individual classes to be scannned, copying Scannotation behavior from AnnotationDB.scanClass()

### DIFF
--- a/src/main/java/org/reflections/vfs/ClassFileDir.java
+++ b/src/main/java/org/reflections/vfs/ClassFileDir.java
@@ -1,0 +1,40 @@
+package org.reflections.vfs;
+
+import java.util.Collections;
+
+import org.reflections.vfs.SystemDir;
+import org.reflections.vfs.SystemFile;
+import org.reflections.vfs.Vfs.Dir;
+import org.reflections.vfs.Vfs.File;
+
+/**
+ * Implementation of Dir representing a class file.
+ */
+public class ClassFileDir implements Dir
+{
+
+    private final java.io.File file;
+
+    public ClassFileDir(java.io.File file)
+    {
+        this.file = file;
+    }
+
+    @Override
+    public String getPath()
+    {
+        return this.file.getName();
+    }
+
+    @Override
+    public Iterable<File> getFiles()
+    {
+        return Collections.singleton((Vfs.File) new SystemFile(new SystemDir(this.file.getParentFile()), this.file));
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+}

--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -299,6 +300,25 @@ public abstract class Vfs {
             public Dir createDir(final URL url) throws Exception {
                 return new JarInputDir(url);
             }
-        }
+        },
+
+		classfile {
+
+			@Override
+			public boolean matches(URL url) throws Exception {
+		        return url.getProtocol().equals("file") && hasClassFileInPath(url);
+			}
+
+			@Override
+			public Dir createDir(URL url) throws Exception {
+		        return new ClassFileDir(Paths.get(url.toURI()).toFile());
+			}
+
+		    private boolean hasClassFileInPath(URL url)
+		    {
+		        return url.toExternalForm().matches(".*\\.class");
+		    }
+
+		}
     }
 }

--- a/src/test/java/org/reflections/VfsTest.java
+++ b/src/test/java/org/reflections/VfsTest.java
@@ -23,6 +23,7 @@ import org.reflections.util.ClasspathHelper;
 import org.reflections.vfs.JarInputDir;
 import org.reflections.vfs.SystemDir;
 import org.reflections.vfs.Vfs;
+import org.reflections.vfs.Vfs.Dir;
 import org.reflections.vfs.ZipDir;
 
 import com.google.common.base.Predicates;
@@ -175,6 +176,13 @@ public class VfsTest {
         final Iterable<Vfs.File> files = Vfs.findFiles(java.util.Arrays.asList(jar), Predicates.<Vfs.File>alwaysTrue());
         assertNotNull(files);
         assertTrue(files.iterator().hasNext());
+    }
+    
+    @Test
+    public void vfsFromUrlForClassFile() {
+        URL thisUrl = ClasspathHelper.forClass(getClass());
+        Dir classFileDir = Vfs.fromURL(thisUrl);
+        assertNotNull(classFileDir);
     }
 
     private void testVfsDir(URL url) {


### PR DESCRIPTION
Changing an internal tool that used Scannotation to use reflections, I found that there wasn't capability to scan individual class files. Just adding to Vfs made that happen, and thought others may want similar behavior.