### PR TITLE
Adds LICENSE.txt to clarify dual licenses listed in pom

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,8 @@
+Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+This program and the accompanying materials are dual-licensed under
+either the terms of the WTFPL (http://www.wtfpl.net)
+ 
+  or (per the licensee's choosing)
+ 
+under the terms of the The New BSD License (http://www.opensource.org/licenses/bsd-license.html)


### PR DESCRIPTION
Given the inclusion of WTFPL, I assume the listing of two licenses in the pom is an either or, not a combination. If that assumption is true, this commit adds that clarity using language similar to another dual licensed repo: https://github.com/qos-ch/logback/blob/master/LICENSE.txt
Reference Issue #250 