### PR TITLE
Fixes for jdk11

### DIFF
--- a/src/main/java/org/reflections/util/ClasspathHelper.java
+++ b/src/main/java/org/reflections/util/ClasspathHelper.java
@@ -188,6 +188,19 @@ public abstract class ClasspathHelper {
                 classLoader = classLoader.getParent();
             }
         }
+        if (result.isEmpty()) {
+            String[] classPathEntries = System
+                    .getProperty("java.class.path")
+                    .split(File.pathSeparator);
+            for (String entry : classPathEntries) {
+                try {
+                    result.add(new URL("file://" + entry));
+                } catch (MalformedURLException ex) {
+                    Reflections.log.warn("Could not convert {} to url.", entry);
+                    Reflections.log.trace("Exception:", ex);
+                }
+            }
+        }
         return distinctUrls(result);
     }
 

--- a/src/test/java/org/reflections/ClasspathHelperTest.java
+++ b/src/test/java/org/reflections/ClasspathHelperTest.java
@@ -3,7 +3,6 @@ package org.reflections;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reflections.util.ClasspathHelper;
-import sun.misc.ClassLoaderUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/test/java/org/reflections/VfsTest.java
+++ b/src/test/java/org/reflections/VfsTest.java
@@ -58,7 +58,7 @@ public class VfsTest {
         }
 
         {
-            URL rtJarUrl = ClasspathHelper.forClass(String.class);
+            URL rtJarUrl = ClasspathHelper.forClass(Predicates.class);
             assertTrue(rtJarUrl.toString().startsWith("jar:file:"));
             assertTrue(rtJarUrl.toString().contains(".jar!"));
 
@@ -69,12 +69,15 @@ public class VfsTest {
             Vfs.Dir dir = Vfs.DefaultUrlTypes.jarUrl.createDir(rtJarUrl);
             Vfs.File file = null;
             for (Vfs.File f : dir.getFiles()) {
-                if (f.getRelativePath().equals("java/lang/String.class")) { file = f; break; }
+                if (f.getRelativePath().equals("com/google/common/base/Predicates.class")) {
+                    file = f;
+                    break;
+                }
             }
 
             ClassFile stringCF = mdAdapter.getOrCreateClassObject(file);
             String className = mdAdapter.getClassName(stringCF);
-            assertTrue(className.equals("java.lang.String"));
+            assertTrue(className.equals("com.google.common.base.Predicates"));
         }
 
         {
@@ -149,7 +152,7 @@ public class VfsTest {
     
     @Test
     public void vfsFromDirWithinAJarUrl() throws MalformedURLException {
-    	URL directoryInJarUrl = ClasspathHelper.forClass(String.class);
+        URL directoryInJarUrl = ClasspathHelper.forClass(Predicates.class);
         assertTrue(directoryInJarUrl.toString().startsWith("jar:file:"));
         assertTrue(directoryInJarUrl.toString().contains(".jar!"));
         


### PR DESCRIPTION
This PR makes finding classes work for Java 11.
If none of the ClassLoaders are `URLClassLoader`, use the property `java.class.path` to find all classes.

This might also fix #202 