### PR TITLE
Updating dom4j to 2.1.1 to resolve security vuln CVE-2018-1000632

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         </dependency>
 
         <dependency>
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.1</version>
             <optional>true</optional> <!-- case: when no xml de/serialization -->
         </dependency>
 


### PR DESCRIPTION
Signed-off-by: Chris Hupman <chupman@us.ibm.com>

One thing to note is that dom4j 2.1.1 is for java 8. I could tell what the minimum supported version was, but if it's Java 7 dom4j 2.0.3 should also resolve the vuln once it's out. 

Since it's to resolve a security vulnerability I'm really hoping it will be possible to push out a new release even though it's been awhile. 

fixes #259 