### PR TITLE
Add Meta Annotation support

### DIFF
--- a/src/main/java/org/reflections/scanners/MetaAnnotationScanner.java
+++ b/src/main/java/org/reflections/scanners/MetaAnnotationScanner.java
@@ -1,0 +1,32 @@
+package org.reflections.scanners;
+
+import javassist.bytecode.AccessFlag;
+import javassist.bytecode.ClassFile;
+import org.reflections.Store;
+
+import java.util.List;
+
+@SuppressWarnings({"unchecked"})
+public class MetaAnnotationScanner extends AbstractScanner {
+    public void scan(final Object cls, Store store) {
+        if(cls instanceof ClassFile) {
+            ClassFile c = (ClassFile) cls;
+            boolean isAnnotation = (c.getAccessFlags() & AccessFlag.ANNOTATION) > 0;
+
+            if(!isAnnotation)
+                return;
+
+            List<String> metaAnnotations = getMetadataAdapter().getClassAnnotationNames(cls);
+
+            String clsName = getMetadataAdapter().getClassName(cls);
+
+            metaAnnotations.add(clsName);
+
+            for (String metaAnnotation : metaAnnotations) {
+                if (acceptResult(metaAnnotation)) {
+                    put(store, metaAnnotation, clsName);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/reflections/ReflectionsCollectTest.java
+++ b/src/test/java/org/reflections/ReflectionsCollectTest.java
@@ -3,6 +3,7 @@ package org.reflections;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.reflections.scanners.MemberUsageScanner;
+import org.reflections.scanners.MetaAnnotationScanner;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.MethodParameterNamesScanner;
 import org.reflections.scanners.MethodParameterScanner;
@@ -35,7 +36,8 @@ public class ReflectionsCollectTest extends ReflectionsTest {
                         new TypeAnnotationsScanner(),
                         new MethodAnnotationsScanner(),
                         new MethodParameterNamesScanner(),
-                        new MemberUsageScanner()));
+                        new MemberUsageScanner(),
+                        new MetaAnnotationScanner()));
 
         ref.save(getUserDir() + "/target/test-classes" + "/META-INF/reflections/testModel-reflections.xml");
 

--- a/src/test/java/org/reflections/ReflectionsParallelTest.java
+++ b/src/test/java/org/reflections/ReflectionsParallelTest.java
@@ -3,6 +3,7 @@ package org.reflections;
 import org.junit.BeforeClass;
 import org.reflections.scanners.FieldAnnotationsScanner;
 import org.reflections.scanners.MemberUsageScanner;
+import org.reflections.scanners.MetaAnnotationScanner;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.MethodParameterNamesScanner;
 import org.reflections.scanners.MethodParameterScanner;
@@ -28,7 +29,8 @@ public class ReflectionsParallelTest extends ReflectionsTest {
                         new MethodAnnotationsScanner(),
                         new MethodParameterScanner(),
                         new MethodParameterNamesScanner(),
-                        new MemberUsageScanner())
+                        new MemberUsageScanner(),
+                        new MetaAnnotationScanner())
                 .useParallelExecutor());
     }
 }

--- a/src/test/java/org/reflections/ReflectionsTest.java
+++ b/src/test/java/org/reflections/ReflectionsTest.java
@@ -7,6 +7,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.reflections.scanners.FieldAnnotationsScanner;
 import org.reflections.scanners.MemberUsageScanner;
+import org.reflections.scanners.MetaAnnotationScanner;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.MethodParameterNamesScanner;
 import org.reflections.scanners.MethodParameterScanner;
@@ -55,7 +56,9 @@ public class ReflectionsTest {
                         new MethodAnnotationsScanner(),
                         new MethodParameterScanner(),
                         new MethodParameterNamesScanner(),
-                        new MemberUsageScanner()));
+                        new MemberUsageScanner(),
+                        new MetaAnnotationScanner()
+                ));
     }
 
     @Test
@@ -167,7 +170,8 @@ public class ReflectionsTest {
             assertThat(reflections.getMethodsMatchParams(),
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m3"),
                             AC2.class.getMethod("value"), AF1.class.getMethod("value"), AM1.class.getMethod("value"),
-                            Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method")));
+                            Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method"),
+                            MetaClass.class.getDeclaredMethod("testMethod1"), MetaClass.class.getDeclaredMethod("testMethod2")));
 
             assertThat(reflections.getMethodsMatchParams(int[][].class, String[][].class),
                     are(C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
@@ -182,7 +186,8 @@ public class ReflectionsTest {
             assertThat(reflections.getMethodsReturn(void.class),
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m1", int.class, String[].class),
                             C4.class.getDeclaredMethod("m1", int[][].class, String[][].class), Usage.C1.class.getDeclaredMethod("method"),
-                            Usage.C1.class.getDeclaredMethod("method", String.class), Usage.C2.class.getDeclaredMethod("method")));
+                            Usage.C1.class.getDeclaredMethod("method", String.class), Usage.C2.class.getDeclaredMethod("method"),
+                            MetaClass.class.getDeclaredMethod("testMethod1"), MetaClass.class.getDeclaredMethod("testMethod2")));
 
             assertThat(reflections.getMethodsWithAnyParamAnnotated(AM1.class),
                     are(C4.class.getDeclaredMethod("m4", String.class)));
@@ -206,7 +211,8 @@ public class ReflectionsTest {
         assertThat(reflections.getConstructorsMatchParams(),
                 are(C1.class.getDeclaredConstructor(), C2.class.getDeclaredConstructor(), C3.class.getDeclaredConstructor(),
                         C4.class.getDeclaredConstructor(), C5.class.getDeclaredConstructor(), C6.class.getDeclaredConstructor(),
-                        C7.class.getDeclaredConstructor(), Usage.C1.class.getDeclaredConstructor(), Usage.C2.class.getDeclaredConstructor()));
+                        C7.class.getDeclaredConstructor(), Usage.C1.class.getDeclaredConstructor(), Usage.C2.class.getDeclaredConstructor(),
+                        MetaClass.class.getDeclaredConstructor()));
 
         assertThat(reflections.getConstructorsWithAnyParamAnnotated(AM1.class),
                 are(C4.class.getDeclaredConstructor(String.class)));
@@ -272,6 +278,36 @@ public class ReflectionsTest {
 
         assertThat(reflections.getConstructorUsage(Usage.C1.class.getDeclaredConstructor(Usage.C2.class)),
                 are(Usage.C2.class.getDeclaredMethod("method")));
+    }
+
+    @Test
+    public void testMetaAnnotatedMethods() {
+        try {
+            assertThat(reflections.getMethodsAnnotatedWithIncludingMetaAnnotations(Annotation1.class),
+                    are(MetaClass.class.getDeclaredMethod("testMethod1"),
+                            MetaClass.class.getDeclaredMethod("testMethod2")
+                    ));
+        } catch (NoSuchMethodException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMetaAnnotatedFields() {
+        try {
+            assertThat(reflections.getFieldsAnnotatedWithIncludingMetaAnnotations(Annotation1.class),
+                    are(MetaClass.class.getDeclaredField("testField1"),
+                            MetaClass.class.getDeclaredField("testField2")
+                    ));
+        } catch (NoSuchFieldException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMetaAnnotatedClasses() {
+        assertThat(reflections.getTypesAnnotatedWithIncludingMetaAnnotations(Annotation1.class, false),
+                are(MetaAnnotation1.class, MetaClass.TestClass1.class, MetaClass.TestClass2.class));
     }
 
     @Test

--- a/src/test/java/org/reflections/TestModel.java
+++ b/src/test/java/org/reflections/TestModel.java
@@ -73,4 +73,26 @@ public interface TestModel {
             }
         }
     }
+
+    public @Retention(RUNTIME) @Inherited @interface Annotation1 {}
+    public @Retention(RUNTIME) @Annotation1 @interface MetaAnnotation1 {}
+
+    public class MetaClass {
+
+        @MetaAnnotation1
+        int testField1;
+        @Annotation1
+        int testField2;
+
+        @MetaAnnotation1
+        public void testMethod1() {}
+
+        @Annotation1
+        public void testMethod2() {}
+
+        @MetaAnnotation1
+        public class TestClass1 {}
+        @Annotation1
+        public class TestClass2 {}
+    }
 }

--- a/src/test/java/org/reflections/VfsTest.java
+++ b/src/test/java/org/reflections/VfsTest.java
@@ -110,7 +110,7 @@ public class VfsTest {
         try {
             Vfs.Dir dir = Vfs.fromURL(new URL(format("file:{0}", dirWithJarInName)));
 
-            assertEquals(dirWithJarInName, dir.getPath());
+            assertEquals(dirWithJarInName.replace("\\", "/"), dir.getPath());
             assertEquals(SystemDir.class, dir.getClass());
         } finally {
             newDir.delete();


### PR DESCRIPTION
These changes allow for looking up MetaAnnotations on methods, fields, and types.

I am not 100% sure about the implementation of `Reflection.getTypesAnnotatedWithIncludingMetaAnnotations` and the way the `@Inherited` annotation is treated and if additional things need to be considered for this case.