### PR TITLE
Fix ConfigurationBuilder addClassLoaders

### DIFF
--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -301,9 +301,9 @@ public class ConfigurationBuilder implements Configuration {
 
     /** add class loader, might be used for resolving methods/fields */
     public ConfigurationBuilder addClassLoaders(ClassLoader... classLoaders) {
-        this.classLoaders = this.classLoaders == null ? classLoaders :
-                Stream.concat(Stream.concat(Arrays.stream(this.classLoaders), Arrays.stream(classLoaders)), Stream.of(ClassLoader.class))
-                        .distinct().toArray(ClassLoader[]::new);
+        this.classLoaders = this.classLoaders == null
+                            ? classLoaders
+                            : Stream.concat(Arrays.stream(this.classLoaders), Arrays.stream(classLoaders)).toArray(ClassLoader[]::new);
         return this;
     }
 

--- a/src/test/java/org/reflections/util/ConfigurationBuilderTest.java
+++ b/src/test/java/org/reflections/util/ConfigurationBuilderTest.java
@@ -1,0 +1,22 @@
+package org.reflections.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ConfigurationBuilderTest
+{
+    @Test
+    public void testCallingAddClassLoaderMoreThanOnce()
+    {
+        ClassLoader fooClassLoader = new ClassLoader() { };
+        ClassLoader barClassLoader = new ClassLoader() { };
+
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
+                .addClassLoader( fooClassLoader  );
+
+        // Attempt to add a second class loader
+        configurationBuilder.addClassLoader( barClassLoader );
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
The `addClassLoaders(ClassLoader ... classloaders)` was trying to concatenate `ClassLoader.class` to the stream of classloaders, and the `toArray()` method would fail given that `ClassLoader.class` is not of type `ClassLoader`.

Notice that I could not understand why there is interest in adding the `ClassLoader.class` so my solution was to remove it. 

If what we are seeking is that the class loader of the `ClassLoader` is to be added, then probably we are missing a `ClassLoader.class.getClassLoader()`. But doing so would be inconsistent as the following would not produce same output:

```
ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addClassLoader( foo ).addClassLoader( bar );
```

```
ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addClassLoader( foo, bar );
```
In the second case, the `ClassLoader.class` would be ignored, because the `ClassLoader[] classLoaders` field of the `ConfigurationBuilder` is null and then `classLoaders` would simply match the passed `{ foo, bar }` array.