### PR TITLE
Try to fix ronmamo/reflections#253

### DIFF
--- a/src/main/java/org/reflections/util/Utils.java
+++ b/src/main/java/org/reflections/util/Utils.java
@@ -53,7 +53,7 @@ public abstract class Utils {
      * Parses the member descriptor and finds the specified member along the inheritance chain
      *
      * @param descriptor   describes a member (constructor/method/field) of a class and consists of the class name,
-     *                     the member name, and the line number of usage
+     *                     the member name, and the line number of constructor/method usage (optional)
      * @param classLoaders one of which is responsible for loading the class specified by the descriptor
      * @return a reflected member specified by the descriptor
      * @throws ReflectionsException if no such member is found along the inheritance chain
@@ -76,7 +76,7 @@ public abstract class Utils {
         Class<?> aClass = forName(className, classLoaders);
         while (aClass != null) {
             try {
-                if (!descriptor.contains("(")) {
+                if (p0 == -1) { // field descriptor: doesn't contain '('
                     return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
                 } else if (isConstructor(descriptor)) {
                     return aClass.isInterface() ? aClass.getConstructor(parameterTypes) : aClass.getDeclaredConstructor(parameterTypes);

--- a/src/main/java/org/reflections/util/Utils.java
+++ b/src/main/java/org/reflections/util/Utils.java
@@ -49,12 +49,21 @@ public abstract class Utils {
         return file;
     }
 
+    /**
+     * Parses the member descriptor and finds the specified member along the inheritance chain
+     *
+     * @param descriptor   describes a member (constructor/method/field) of a class and consists of the class name,
+     *                     the member name, and the line number of usage
+     * @param classLoaders one of which is responsible for loading the class specified by the descriptor
+     * @return a reflected member specified by the descriptor
+     * @throws ReflectionsException if no such member is found along the inheritance chain
+     */
     public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) throws ReflectionsException {
         int p0 = descriptor.lastIndexOf('(');
         String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
         String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
 
-        int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"));
+        int p1 = memberKey.lastIndexOf('.');
         String className = memberKey.substring(0, p1);
         String memberName = memberKey.substring(p1 + 1);
 

--- a/src/test/java/org/reflections/ReflectionUtilsTest.java
+++ b/src/test/java/org/reflections/ReflectionUtilsTest.java
@@ -4,6 +4,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Test;
 import org.reflections.scanners.FieldAnnotationsScanner;
+import org.reflections.util.Utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -129,6 +130,49 @@ public class ReflectionUtilsTest {
         Set<? extends Field> allFields = ReflectionUtils.getAll(af1, withModifier(Modifier.PROTECTED));
         assertEquals(1, allFields.size());
         assertThat(allFields, names("f2"));
+    }
+
+    @Test
+    public void testGetMemberFromDescriptor() throws NoSuchMethodException, NoSuchFieldException {
+        // field
+        Member c1Field = Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C1.c2",
+                TestModel.class.getClassLoader());
+        assertEquals(TestModel.Usage.C1.class.getDeclaredField("c2"), c1Field);
+
+        // constructor
+        Member c1Constructor = Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C1.<init>(org.reflections.TestModel$Usage$C2)",
+                TestModel.class.getClassLoader());
+        assertEquals(TestModel.Usage.C1.class.getConstructor(TestModel.Usage.C2.class), c1Constructor);
+
+        // method
+        Member c2Method = Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C2.method()",
+                TestModel.class.getClassLoader());
+        assertEquals(TestModel.Usage.C2.class.getDeclaredMethod("method"), c2Method);
+
+        // synthetic method for lambda expression
+        Member c2Lambda = Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C2.lambda$useLambda$0(org.reflections.TestModel$Usage$C1)",
+                TestModel.class.getClassLoader());
+        assertEquals(TestModel.Usage.C2.class.getDeclaredMethod("lambda$useLambda$0", TestModel.Usage.C1.class), c2Lambda);
+
+        // method of anonymous inner class
+        Member anonymousClassMethod = Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C2$1.applyAsDouble(org.reflections.TestModel$Usage$C1)",
+                TestModel.class.getClassLoader());
+        assertEquals(anonymousClassMethod.getName(), "applyAsDouble");
+    }
+
+    @Test(expected = ReflectionsException.class)
+    public void testGetMemberFromDescriptorFieldNotFound() {
+        Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C1.fieldNotExist");
+    }
+
+    @Test(expected = ReflectionsException.class)
+    public void testGetMemberFromDescriptorConstructorNotFound() {
+        Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C1.<init>(int)");
+    }
+
+    @Test(expected = ReflectionsException.class)
+    public void testGetMemberFromDescriptorMethodNotFound() {
+        Utils.getMemberFromDescriptor("org.reflections.TestModel$Usage$C1.methodNotExist()");
     }
 
     private Set<String> names(Set<? extends Member> o) {

--- a/src/test/java/org/reflections/ReflectionsTest.java
+++ b/src/test/java/org/reflections/ReflectionsTest.java
@@ -167,7 +167,8 @@ public class ReflectionsTest {
             assertThat(reflections.getMethodsMatchParams(),
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m3"),
                             AC2.class.getMethod("value"), AF1.class.getMethod("value"), AM1.class.getMethod("value"),
-                            Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method")));
+                            Usage.C1.class.getDeclaredMethod("method"), Usage.C1.class.getDeclaredMethod("zero"),
+                            Usage.C2.class.getDeclaredMethod("method")));
 
             assertThat(reflections.getMethodsMatchParams(int[][].class, String[][].class),
                     are(C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
@@ -272,6 +273,15 @@ public class ReflectionsTest {
 
         assertThat(reflections.getConstructorUsage(Usage.C1.class.getDeclaredConstructor(Usage.C2.class)),
                 are(Usage.C2.class.getDeclaredMethod("method")));
+    }
+
+    @Test
+    public void testMemberUsageScannerWithFunctionalUsage() throws NoSuchMethodException {
+        Class<?> anonymousClass = ReflectionUtils.forName("org.reflections.TestModel$Usage$C2$1");
+        assertNotNull(anonymousClass);
+        assertThat(reflections.getMethodUsage(Usage.C1.class.getDeclaredMethod("zero")),
+                are(anonymousClass.getDeclaredMethod("applyAsDouble", Usage.C1.class),
+                        Usage.C2.class.getDeclaredMethod("lambda$useLambda$0", Usage.C1.class)));
     }
 
     @Test

--- a/src/test/java/org/reflections/TestModel.java
+++ b/src/test/java/org/reflections/TestModel.java
@@ -2,7 +2,6 @@ package org.reflections;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Inherited;
-import java.util.function.Consumer;
 import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 

--- a/src/test/java/org/reflections/TestModel.java
+++ b/src/test/java/org/reflections/TestModel.java
@@ -2,6 +2,10 @@ package org.reflections;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Inherited;
+import java.util.function.Consumer;
+import java.util.function.ToDoubleFunction;
+import java.util.stream.Stream;
+
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -62,6 +66,7 @@ public interface TestModel {
             public C1(C2 c2) { this.c2 = c2; }
             public void method() { c2.method(); }
             public void method(String string) { c2.method(); }
+            public double zero() { return 0; }
         }
         public static class C2 {
             C1 c1 = new C1();
@@ -70,6 +75,21 @@ public interface TestModel {
                 c1 = new C1(this);
                 c1.method();
                 c1.method("");
+            }
+            public double useAnonymousClass(C1... objects) {
+                return Stream.of(objects)
+                        .mapToDouble(new ToDoubleFunction<C1>() {
+                            @Override
+                            public double applyAsDouble(C1 c1) {
+                                return c1.zero();
+                            }
+                        })
+                        .sum();
+            }
+            public double useLambda(C1... objects) {
+                return Stream.of(objects)
+                        .mapToDouble(it -> it.zero())
+                        .sum();
             }
         }
     }


### PR DESCRIPTION
This PR tries to fix ronmano/reflections#253 by using only the last dot to seperate class name and member name to get a correct name of the synthetic method for lambda expression usage.

Format of the names of synthetic methods for lambda expression body:
`lambda$methodNameWhereTheLambdaExprAppears$#` where `#` is a number

The last dot is also the delimiter of class name and member name in the earlier implementation. It was then changed to `Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"))` but I don't know under what circumstance will the last dollar be a proper delimiter. Please double check my changes.

Test cases are added for both lambda usage and anonymous class usage, as OpenJDK compiler generates different bytecodes for them.

The problem mentioned in ronmamo/reflections#280 about extracting the expected outer method instead of the synthetic one has not been solved in this PR.