### PR TITLE
Modify the file path format to  be platform-compatible 

### DIFF
--- a/src/test/java/org/reflections/VfsTest.java
+++ b/src/test/java/org/reflections/VfsTest.java
@@ -110,7 +110,7 @@ public class VfsTest {
         try {
             Vfs.Dir dir = Vfs.fromURL(new URL(format("file:{0}", dirWithJarInName)));
 
-            assertEquals(dirWithJarInName, dir.getPath());
+            assertEquals(dirWithJarInName.replace("\\", "/"), dir.getPath());
             assertEquals(SystemDir.class, dir.getClass());
         } finally {
             newDir.delete();


### PR DESCRIPTION
In Windows platform, a test case will fail because the format of the obtained file path is different from the expected one. 
This is described in the #298 .