### PR TITLE
Removed dependency on dom4J - XmlSerializer now uses core JDK classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>2.1.1</version>
-            <optional>true</optional> <!-- case: when no xml de/serialization -->
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.6</version>

--- a/src/main/java/org/reflections/serializers/XmlSerializer.java
+++ b/src/main/java/org/reflections/serializers/XmlSerializer.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -62,6 +63,15 @@ public class XmlSerializer implements Serializer {
         try {
 
             final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities",
+                                     false);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities",
+                                     false);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                                     false);
+
             final SAXParser parser = parserFactory.newSAXParser();
 
             final ReflectionsXMLHandler handler = new ReflectionsXMLHandler();

--- a/src/main/java/org/reflections/serializers/XmlSerializer.java
+++ b/src/main/java/org/reflections/serializers/XmlSerializer.java
@@ -1,28 +1,40 @@
 package org.reflections.serializers;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentFactory;
-import org.dom4j.Element;
-import org.dom4j.io.OutputFormat;
-import org.dom4j.io.SAXReader;
-import org.dom4j.io.XMLWriter;
-import org.reflections.Reflections;
-import org.reflections.ReflectionsException;
-import org.reflections.Store;
-import org.reflections.util.ConfigurationBuilder;
-import org.reflections.util.Utils;
-
 import java.io.File;
-import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 
-/** serialization of Reflections to xml
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.reflections.Reflections;
+import org.reflections.ReflectionsException;
+import org.reflections.Store;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.Utils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * serialization of Reflections to xml
+ * <p>
+ * an example of produced xml:
  *
- * <p>an example of produced xml:
  * <pre>
  * &#60?xml version="1.0" encoding="UTF-8"?>
  *
@@ -35,90 +47,195 @@ import java.lang.reflect.Constructor;
  *              &#60value>fully.qualified.name.2&#60/value>
  * ...
  * </pre>
- * */
+ */
 public class XmlSerializer implements Serializer {
 
-    public Reflections read(InputStream inputStream) {
-        Reflections reflections;
-        try {
-            Constructor<Reflections> constructor = Reflections.class.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            reflections = constructor.newInstance();
-        } catch (Exception e) {
-            reflections = new Reflections(new ConfigurationBuilder());
-        }
+    private static final String ELEM_ROOT = "Reflections";
+    private static final String ELEM_KEY = "key";
+    private static final String ELEM_ENTRY = "entry";
+    private static final String ELEM_VALUES = "values";
+    private static final String ELEM_VALUE = "value";
+
+    @Override
+    public Reflections read(final InputStream inputStream) {
 
         try {
-            Document document = new SAXReader().read(inputStream);
-            for (Object e1 : document.getRootElement().elements()) {
-                Element index = (Element) e1;
-                for (Object e2 : index.elements()) {
-                    Element entry = (Element) e2;
-                    Element key = entry.element("key");
-                    Element values = entry.element("values");
-                    for (Object o3 : values.elements()) {
-                        Element value = (Element) o3;
-                        reflections.getStore().put(index.getName(), key.getText(), value.getText());
-                    }
-                }
-            }
-        } catch (DocumentException e) {
-            throw new ReflectionsException("could not read.", e);
-        } catch (Throwable e) {
-            throw new RuntimeException("Could not read. Make sure relevant dependencies exist on classpath.", e);
+
+            final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            final SAXParser parser = parserFactory.newSAXParser();
+
+            final ReflectionsXMLHandler handler = new ReflectionsXMLHandler();
+
+            parser.parse(inputStream, handler);
+
+            return handler.reflections;
+
+        } catch (final Throwable e) {
+            throw new RuntimeException("Could not read. Make sure relevant dependencies exist on classpath.",
+                                       e);
         }
 
-        return reflections;
     }
 
+    @Override
     public File save(final Reflections reflections, final String filename) {
-        File file = Utils.prepareFile(filename);
+        final File file = Utils.prepareFile(filename);
 
+        try (final FileWriter writer = new FileWriter(file)) {
+            final Document document = createDocument(reflections);
 
-        try {
-            Document document = createDocument(reflections);
-            XMLWriter xmlWriter = new XMLWriter(new FileOutputStream(file), OutputFormat.createPrettyPrint());
-            xmlWriter.write(document);
-            xmlWriter.close();
-        } catch (IOException e) {
+            final Transformer tf = TransformerFactory.newInstance().newTransformer();
+            tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            tf.setOutputProperty(OutputKeys.INDENT, "yes");
+            tf.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+            tf.transform(new DOMSource(document), new StreamResult(writer));
+
+        } catch (final IOException e) {
             throw new ReflectionsException("could not save to file " + filename, e);
-        } catch (Throwable e) {
-            throw new RuntimeException("Could not save to file " + filename + ". Make sure relevant dependencies exist on classpath.", e);
+        } catch (final Throwable e) {
+            throw new RuntimeException("Could not save to file " + filename
+                    + ". Make sure relevant dependencies exist on classpath.", e);
         }
 
         return file;
     }
 
+    @Override
     public String toString(final Reflections reflections) {
-        Document document = createDocument(reflections);
 
         try {
-            StringWriter writer = new StringWriter();
-            XMLWriter xmlWriter = new XMLWriter(writer, OutputFormat.createPrettyPrint());
-            xmlWriter.write(document);
-            xmlWriter.close();
+            final Document document = createDocument(reflections);
+            final StringWriter writer = new StringWriter();
+
+            final Transformer tf = TransformerFactory.newInstance().newTransformer();
+            tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            tf.setOutputProperty(OutputKeys.INDENT, "yes");
+            tf.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+            tf.transform(new DOMSource(document), new StreamResult(writer));
+
             return writer.toString();
-        } catch (IOException e) {
-            throw new RuntimeException();
+
+        } catch (final ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        } catch (final TransformerException e) {
+            throw new RuntimeException(e);
         }
     }
 
-    private Document createDocument(final Reflections reflections) {
-        Store map = reflections.getStore();
+    private Document createDocument(final Reflections reflections)
+            throws ParserConfigurationException {
+        final Store map = reflections.getStore();
 
-        Document document = DocumentFactory.getInstance().createDocument();
-        Element root = document.addElement("Reflections");
-        for (String indexName : map.keySet()) {
-            Element indexElement = root.addElement(indexName);
-            for (String key : map.keys(indexName)) {
-                Element entryElement = indexElement.addElement("entry");
-                entryElement.addElement("key").setText(key);
-                Element valuesElement = entryElement.addElement("values");
-                for (String value : map.get(indexName, key)) {
-                    valuesElement.addElement("value").setText(value);
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = dbf.newDocumentBuilder();
+
+        final Document document = builder.newDocument();
+        document.setXmlStandalone(true);
+
+        final Element root = document.createElement(ELEM_ROOT);
+        document.appendChild(root);
+
+        for (final String indexName : map.keySet()) {
+            final Element indexElement = document.createElement(indexName);
+            root.appendChild(indexElement);
+
+            for (final String key : map.keys(indexName)) {
+                final Element entryElement = document.createElement(ELEM_ENTRY);
+                indexElement.appendChild(entryElement);
+
+                final Element keyElement = document.createElement(ELEM_KEY);
+                keyElement.setTextContent(key);
+                entryElement.appendChild(keyElement);
+
+                final Element valuesElement = document.createElement(ELEM_VALUES);
+                entryElement.appendChild(valuesElement);
+
+                for (final String value : map.get(indexName, key)) {
+                    final Element valueElement = document.createElement(ELEM_VALUE);
+                    valueElement.setTextContent(value);
+                    valuesElement.appendChild(valueElement);
                 }
             }
         }
         return document;
     }
+
+    private class ReflectionsXMLHandler extends DefaultHandler {
+
+        public Reflections reflections;
+
+        private String indexName;
+
+        private String key;
+
+        private final StringBuilder buffer = new StringBuilder();
+
+        public ReflectionsXMLHandler() {
+            try {
+                final Constructor<Reflections> constructor = Reflections.class.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                reflections = constructor.newInstance();
+            } catch (@SuppressWarnings("unused") final Exception e) {
+                reflections = new Reflections(new ConfigurationBuilder());
+            }
+
+        }
+
+        @Override
+        public void startElement(final String uri, final String localName, final String qName,
+                                 final Attributes attributes)
+                throws SAXException {
+
+            drainBuffer();
+
+            if (ELEM_ROOT.equals(qName)) {
+                return;
+            }
+
+            if (indexName == null) {
+                indexName = qName;
+                return;
+            }
+
+        }
+
+        @Override
+        public void endElement(final String uri, final String localName, final String qName)
+                throws SAXException {
+
+            final String text = drainBuffer();
+
+            if (ELEM_ROOT.equals(qName)) {
+                return; // Done
+            }
+
+            if (qName.equals(indexName)) {
+                indexName = null;
+
+            } else if (ELEM_KEY.equals(qName)) {
+                key = text;
+
+            } else if (ELEM_VALUE.equals(qName)) {
+
+                reflections.getStore().put(indexName, key, text);
+
+            }
+        }
+
+        private String drainBuffer() {
+            final String text = buffer.toString();
+            buffer.setLength(0);
+            return text;
+        }
+
+        @Override
+        public void characters(final char[] ch, final int start, final int length)
+                throws SAXException {
+            buffer.append(ch, start, length);
+        }
+
+    }
+
 }

--- a/src/test/java/org/reflections/serializers/XmlSerializerTest.java
+++ b/src/test/java/org/reflections/serializers/XmlSerializerTest.java
@@ -1,0 +1,134 @@
+package org.reflections.serializers;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.reflections.Configuration;
+import org.reflections.Reflections;
+import org.reflections.Store;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ConfigurationBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class XmlSerializerTest {
+
+    @Rule
+    public final TemporaryFolder tempFolder = TemporaryFolder.builder().build();
+
+    private Configuration config;
+    private XmlSerializer serializer;
+
+    @Before
+    public void setUp() throws Exception {
+
+        config = new ConfigurationBuilder().forPackages("org.reflections.scanners")
+                                           .setScanners(new SubTypesScanner());
+
+        serializer = new XmlSerializer();
+    }
+
+    /**
+     * Scenario: Write out to XML file, read it back in, and compare
+     *
+     * @throws IOException
+     */
+    @Test
+    public final void testRoundtrip() throws IOException {
+
+        final Reflections reflectionsExpected = new Reflections(config);
+        reflectionsExpected.expandSuperTypes();
+
+        final File tempFile = tempFolder.newFile();
+
+        // Serialize to temporary file
+        serializer.save(reflectionsExpected, tempFile.getPath());
+
+        try (InputStream inputStream = new FileInputStream(tempFile)) {
+
+            // Read back XML that was just written
+            final Reflections reflectionsLoaded = serializer.read(inputStream);
+
+            final Store expectedStore = reflectionsExpected.getStore();
+            final Store loadedStore = reflectionsLoaded.getStore();
+
+            for (final String indexName : expectedStore.keySet()) {
+
+                for (final String key : expectedStore.keys(indexName)) {
+
+                    final Set<String> expectedValues = expectedStore.get(indexName, key);
+                    final Set<String> loadedValues = loadedStore.get(indexName, key);
+
+                    assertThat(loadedValues, equalTo(expectedValues));
+
+                }
+
+            }
+
+        }
+
+    }
+
+    @Test
+    public final void testToStringReflections() throws ParserConfigurationException, SAXException,
+            IOException, XPathExpressionException {
+
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        final XPathFactory xpathfactory = XPathFactory.newInstance();
+        final XPath xpath = xpathfactory.newXPath();
+
+        final Reflections reflections = new Reflections("org.reflections.util");
+
+        // Method under test
+        final String xmlString = serializer.toString(reflections);
+
+        final InputSource is = new InputSource(new StringReader(xmlString));
+
+        final Document doc = builder.parse(is);
+
+        NodeList nodes = (NodeList) xpath.evaluate("/Reflections/SubTypesScanner", doc,
+                                                   XPathConstants.NODESET);
+        assertEquals(1, nodes.getLength());
+
+        nodes = (NodeList) xpath.evaluate("//entry/key", doc, XPathConstants.NODESET);
+        assertEquals(5, nodes.getLength());
+
+        nodes = (NodeList) xpath.evaluate("//entry/values/value/text()", doc,
+                                          XPathConstants.NODESET);
+        assertEquals(8, nodes.getLength());
+
+        for (int i = 0; i < nodes.getLength(); i++) {
+            final Node node = nodes.item(i);
+            final String value = node.getNodeValue();
+
+            assertThat(value, containsString("org.reflections.util"));
+        }
+
+    }
+
+}


### PR DESCRIPTION
`dom4J` has been repeatedly vulnerable to XXE attacks, like [CVE-2020-10683](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10683). Removed the dependency on dom4j and reimplemented using core JDK XML classes.