### PR TITLE
Correct the wrong match

### DIFF
--- a/src/main/java/org/reflections/vfs/Vfs.java
+++ b/src/main/java/org/reflections/vfs/Vfs.java
@@ -189,20 +189,24 @@ public abstract class Vfs {
 
         return null;
     }
-    
+
     private static boolean hasJarFileInPath(URL url) {
-		return url.toExternalForm().matches(".*\\.jar(\\!.*|$)");
-	}
+        return url.toExternalForm().matches(".*\\.jar(\\!.*|$)");
+    }
+
+    private static boolean hasInnerJarFileInPath(URL url) {
+        return url.toExternalForm().matches(".+\\.jar\\!.+");
+    }
 
     /** default url types used by {@link org.reflections.vfs.Vfs#fromURL(java.net.URL)}
      * <p>
      * <p>jarFile - creates a {@link org.reflections.vfs.ZipDir} over jar file
-     * <p>jarUrl - creates a {@link org.reflections.vfs.ZipDir} over a jar url (contains ".jar!/" in it's name), using Java's {@link JarURLConnection}
+     * <p>jarUrl - creates a {@link org.reflections.vfs.ZipDir} over a jar url, using Java's {@link JarURLConnection}
      * <p>directory - creates a {@link org.reflections.vfs.SystemDir} over a file system directory
      * <p>jboss vfs - for protocols vfs, using jboss vfs (should be provided in classpath)
      * <p>jboss vfsfile - creates a {@link UrlTypeVFS} for protocols vfszip and vfsfile.
      * <p>bundle - for bundle protocol, using eclipse FileLocator (should be provided in classpath)
-     * <p>jarInputStream - creates a {@link JarInputDir} over jar files, using Java's JarInputStream
+     * <p>jarInputStream - creates a {@link JarInputDir} over jar files (contains ".jar!/" in it's name), using Java's JarInputStream
      * */
     public enum DefaultUrlTypes implements UrlType {
         jarFile {
@@ -217,7 +221,7 @@ public abstract class Vfs {
 
         jarUrl {
             public boolean matches(URL url) {
-                return "jar".equals(url.getProtocol()) || "zip".equals(url.getProtocol()) || "wsjar".equals(url.getProtocol());
+                return ("jar".equals(url.getProtocol()) || "zip".equals(url.getProtocol()) || "wsjar".equals(url.getProtocol())) && !hasInnerJarFileInPath(url);
             }
 
             public Dir createDir(URL url) throws Exception {
@@ -255,7 +259,7 @@ public abstract class Vfs {
             }
 
             public Vfs.Dir createDir(URL url) throws Exception {
-		return JbossDir.createDir(url);
+                return JbossDir.createDir(url);
             }
         },
 

--- a/src/test/java/org/reflections/VfsTest.java
+++ b/src/test/java/org/reflections/VfsTest.java
@@ -8,10 +8,22 @@ import org.reflections.vfs.SystemDir;
 import org.reflections.vfs.Vfs;
 import org.slf4j.Logger;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
 import static java.text.MessageFormat.format;
 import static org.junit.Assert.*;
@@ -117,6 +129,46 @@ public class VfsTest {
         }
     }
 
+    @Test
+    public void vfsFromDirWithJarInJar() {
+        String tmpFolder = System.getProperty("java.io.tmpdir");
+        tmpFolder = tmpFolder.endsWith(File.separator) ? tmpFolder : tmpFolder + File.separator;
+        String dirWithJarInJar = tmpFolder + "jarinjar";
+        try {
+            Path lib = Paths.get(dirWithJarInJar, "BOOT-INF", "lib");
+            if (Files.exists(Paths.get(dirWithJarInJar)))
+                Files.walk(Paths.get(dirWithJarInJar)).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+
+            Files.createDirectories(lib);
+            Path jar = Paths.get(Logger.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            Files.copy(jar, lib.resolve(jar.getFileName()));
+
+            File tempjar = new File(dirWithJarInJar + File.separator + "output.jar");
+            Manifest manifest = new Manifest();
+            manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+            JarOutputStream target = new JarOutputStream(new FileOutputStream(tempjar), manifest);
+            createJar(new File(dirWithJarInJar + File.separator + "BOOT-INF"), new File(dirWithJarInJar), target);
+            target.close();
+
+            URL innerjarurl = new URL(format("jar:{0}!/BOOT-INF/lib/{1}", tempjar.toURI().toString(), jar.getFileName()));
+
+            assertFalse(Vfs.DefaultUrlTypes.jarUrl.matches(innerjarurl));
+            assertTrue(Vfs.DefaultUrlTypes.jarInputStream.matches(innerjarurl));
+
+            Vfs.Dir jarUrlDir = Vfs.DefaultUrlTypes.jarUrl.createDir(innerjarurl);
+            assertNotEquals(innerjarurl.getPath(), jarUrlDir.getPath());
+
+            Vfs.Dir jarInputStreamDir = Vfs.DefaultUrlTypes.jarInputStream.createDir(innerjarurl);
+            assertEquals(innerjarurl.getPath(), jarInputStreamDir.getPath());
+        }  catch (Exception e) {
+        } finally {
+            try {
+                Files.walk(Paths.get(dirWithJarInJar)).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            } catch (IOException e) {
+            }
+        }
+    }
+
     private void testVfsDir(Vfs.Dir dir) {
         JavassistAdapter mdAdapter = new JavassistAdapter();
         Vfs.File file = null;
@@ -130,5 +182,56 @@ public class VfsTest {
         ClassFile stringCF = mdAdapter.getOrCreateClassObject(file);
         String className = mdAdapter.getClassName(stringCF);
         assertFalse(className.isEmpty());
+    }
+
+    private void createJar(File source, File baseDir, JarOutputStream target) {
+        BufferedInputStream in = null;
+
+        try {
+            if (!source.exists()){
+                throw new IOException("Source directory is empty");
+            }
+            if (source.isDirectory()) {
+                // For Jar entries, all path separates should be '/'(OS independent)
+                String name = baseDir.toPath().relativize(source.toPath()).toFile().getPath().replace("\\", "/");
+                if (!name.isEmpty()) {
+                    if (!name.endsWith("/")) {
+                        name += "/";
+                    }
+                    JarEntry entry = new JarEntry(name);
+                    entry.setTime(source.lastModified());
+                    target.putNextEntry(entry);
+                    target.closeEntry();
+                }
+                for (File nestedFile : source.listFiles()) {
+                    createJar(nestedFile, baseDir, target);
+                }
+                return;
+            }
+
+            String entryName = baseDir.toPath().relativize(source.toPath()).toFile().getPath().replace("\\", "/");
+            JarEntry entry = new JarEntry(entryName);
+            entry.setTime(source.lastModified());
+            target.putNextEntry(entry);
+            in = new BufferedInputStream(new FileInputStream(source));
+
+            byte[] buffer = new byte[1024];
+            while (true) {
+                int count = in.read(buffer);
+                if (count == -1)
+                    break;
+                target.write(buffer, 0, count);
+            }
+            target.closeEntry();
+        } catch (Exception ignored) {
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (Exception ignored) {
+                    throw new RuntimeException(ignored);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Correct the wrong match, when process a jar package within a jar package (such as spring-boot, a jar package after `repackage`), should use `jarInputStream` instead of `jarUrl`, because `jarUrl` parses the outermost jar for this scenario.