### PR TITLE
Add subtypes to SubTypes store during expand super types step

### DIFF
--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -333,7 +333,9 @@ public class Reflections implements NameHelper {
     private void expandSupertypes(Map<String, Set<String>> map, String key, Class<?> type) {
         for (Class<?> supertype : ReflectionUtils.getSuperTypes(type)) {
             String supertypeName = supertype.getName();
-            if (!map.containsKey(supertypeName)) {
+            if (map.containsKey(supertypeName)) {
+                map.get(supertypeName).add(key);
+            } else {
                 map.computeIfAbsent(supertypeName, s -> new HashSet<>()).add(key);
                 expandSupertypes(map, supertypeName, supertype);
             }


### PR DESCRIPTION
During expandSuperTypes step if supertype exists subtype is not added to it's supertypes's subtypes.

It should fix #348 .