### PR TITLE
Detect annotations during expand super types step

### DIFF
--- a/src/main/java/org/reflections/Configuration.java
+++ b/src/main/java/org/reflections/Configuration.java
@@ -28,6 +28,6 @@ public interface Configuration {
     ClassLoader[] getClassLoaders();
 
     /** if true (default), expand super types after scanning, for super types that were not scanned.
-     * <p>see {@link org.reflections.Reflections#expandSuperTypes(Map)}*/
+     * <p>see {@link Reflections#expandSuperTypes(Map, Map)}*/
     boolean shouldExpandSuperTypes();
 }

--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -333,7 +333,9 @@ public class Reflections implements NameHelper {
     private void expandSupertypes(Map<String, Set<String>> map, String key, Class<?> type) {
         for (Class<?> supertype : ReflectionUtils.getSuperTypes(type)) {
             String supertypeName = supertype.getName();
-            if (!map.containsKey(supertypeName)) {
+            if (map.containsKey(supertypeName)) {
+                map.get(supertypeName).add(key);
+            } else {
                 map.computeIfAbsent(supertypeName, s -> new HashSet<>()).add(key);
                 expandSupertypes(map, supertypeName, supertype);
             }

--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -81,7 +81,7 @@ import static org.reflections.scanners.Scanners.*;
  * }</pre>
  *
  * <p>All relevant URLs should be configured.
- * <br>If required, Reflections will {@link #expandSuperTypes(Map)} in order to get the transitive closure metadata without scanning large 3rd party urls.
+ * <br>If required, Reflections will {@link #expandSuperTypes(Map, Map)} in order to get the transitive closure metadata without scanning large 3rd party urls.
  * <p>{@link Scanners} must be configured in order to be queried, otherwise an empty result is returned.
  * <br>Default scanners are {@code SubTypes} and {@code TypesAnnotated}.
  * For all standard scanners use {@code Scanners.values()}.
@@ -125,7 +125,7 @@ public class Reflections implements NameHelper {
         this.configuration = configuration;
         Map<String, Map<String, Set<String>>> storeMap = scan();
         if (configuration.shouldExpandSuperTypes()) {
-            expandSuperTypes(storeMap.get(SubTypes.index()));
+            expandSuperTypes(storeMap.get(SubTypes.index()), storeMap.get(TypesAnnotated.index()));
         }
         store = new Store(storeMap);
     }
@@ -317,27 +317,36 @@ public class Reflections implements NameHelper {
      *     <li>if expanding supertypes, B will be expanded with A (A->B in store) - then getSubTypes(A) will return C</li>
      * </ul>
      */
-    public void expandSuperTypes(Map<String, Set<String>> map) {
-        if (map == null || map.isEmpty()) return;
-        Set<String> keys = new LinkedHashSet<>(map.keySet());
-        keys.removeAll(map.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
+    public void expandSuperTypes(Map<String, Set<String>> subTypesStore, Map<String, Set<String>> typesAnnotatedStore) {
+        if (subTypesStore == null || subTypesStore.isEmpty()) return;
+        Set<String> keys = new LinkedHashSet<>(subTypesStore.keySet());
+        keys.removeAll(subTypesStore.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
         keys.remove("java.lang.Object");
         for (String key : keys) {
             Class<?> type = forClass(key, loaders());
             if (type != null) {
-                expandSupertypes(map, key, type);
+                expandSupertypes(subTypesStore, typesAnnotatedStore, key, type);
             }
         }
     }
 
-    private void expandSupertypes(Map<String, Set<String>> map, String key, Class<?> type) {
+    private void expandSupertypes(Map<String, Set<String>> subTypesStore,
+              Map<String, Set<String>> typesAnnotatedStore, String key, Class<?> type) {
+        Set<Annotation> typeAnnotations = ReflectionUtils.getAnnotations(type);
+        if (!typeAnnotations.isEmpty()) {
+            String typeName = type.getName();
+            for (Annotation typeAnnotation : typeAnnotations) {
+                String annotationName = typeAnnotation.annotationType().getName();
+                typesAnnotatedStore.computeIfAbsent(annotationName, s -> new HashSet<>()).add(typeName);
+            }
+        }
         for (Class<?> supertype : ReflectionUtils.getSuperTypes(type)) {
             String supertypeName = supertype.getName();
-            if (map.containsKey(supertypeName)) {
-                map.get(supertypeName).add(key);
+            if (subTypesStore.containsKey(supertypeName)) {
+                subTypesStore.get(supertypeName).add(key);
             } else {
-                map.computeIfAbsent(supertypeName, s -> new HashSet<>()).add(key);
-                expandSupertypes(map, supertypeName, supertype);
+                subTypesStore.computeIfAbsent(supertypeName, s -> new HashSet<>()).add(key);
+                expandSupertypes(subTypesStore, typesAnnotatedStore, supertypeName, supertype);
             }
         }
     }

--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -230,7 +230,7 @@ public class ConfigurationBuilder implements Configuration {
     }
 
     /** if set to true, Reflections will expand super types after scanning.
-     * <p>see {@link org.reflections.Reflections#expandSuperTypes(Map)} */
+     * <p>see {@link org.reflections.Reflections#expandSuperTypes(Map, Map)} */
     public ConfigurationBuilder setExpandSuperTypes(boolean expandSuperTypes) {
         this.expandSuperTypes = expandSuperTypes;
         return this;

--- a/src/test/java/org/reflections/ReflectionsExpandSupertypesTest.java
+++ b/src/test/java/org/reflections/ReflectionsExpandSupertypesTest.java
@@ -1,11 +1,18 @@
 package org.reflections;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
+import test.classes.a.BaseClass;
+import test.classes.a.TestAnnotation;
+import test.classes.b.ChildrenClass;
 
 import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,5 +54,15 @@ public class ReflectionsExpandSupertypesTest {
         assertFalse(refDontExpand.getConfiguration().shouldExpandSuperTypes());
         Collection<Class<? extends TestModel.A>> subTypesOf1 = refDontExpand.getSubTypesOf(TestModel.A.class);
         assertFalse(subTypesOf1.contains(TestModel.B.class));
+    }
+
+    @Test
+    void testDetectInheritedAnnotations() {
+        final Reflections reflections = new Reflections("test.classes.b");
+        final Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(TestAnnotation.class);
+
+        final Set<Class<? extends BaseClass>> expected =
+                Stream.of(BaseClass.class, ChildrenClass.class).collect(Collectors.toSet());
+        Assertions.assertEquals(typesAnnotatedWith, expected);
     }
 }

--- a/src/test/java/test/classes/a/BaseClass.java
+++ b/src/test/java/test/classes/a/BaseClass.java
@@ -1,0 +1,5 @@
+package test.classes.a;
+
+@TestAnnotation
+public class BaseClass {
+}

--- a/src/test/java/test/classes/a/TestAnnotation.java
+++ b/src/test/java/test/classes/a/TestAnnotation.java
@@ -1,0 +1,10 @@
+package test.classes.a;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface TestAnnotation {
+}

--- a/src/test/java/test/classes/b/ChildrenClass.java
+++ b/src/test/java/test/classes/b/ChildrenClass.java
@@ -1,0 +1,6 @@
+package test.classes.b;
+
+import test.classes.a.BaseClass;
+
+public class ChildrenClass extends BaseClass {
+}


### PR DESCRIPTION
I believe it might be benecial to fill missing annotations when expanding supertypes. This step fills only SubTypes store leaving TypesAnnotated store untouched. In our project we have a huge classpath and want to limit scan phase as much as possible. We rely on getTypesAnnotatedWith though so we had our own fork just for this case. 

Do you think it might become part of the library?