### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # todo re-add jdk '9' after missing certificate issue on ubuntu is resolved
-        java: [ '8', '11', '13', '15', '17']
+        java: [ '8.0.192', '8', '11.0.3', '11', '13', '15', '17', '18-ea' ]
         os: [ ubuntu-latest, windows-latest ]
     name: Java ${{ matrix.Java }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
       - name: Show version


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added is a fixed (major) release version(s) such as `JDK 8.0.192`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 8`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 8.0.192` (fixed version) the build/tests passes (Green) and JDK 8 fails (Red) will mean that the latest `JDK 8` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.

I included major fixed releases and JDK 18-ea and all tests have passed 👍🏼 