### PR TITLE
Issue with new releases of OpenJDK and Zulu.  fix #395

### DIFF
--- a/src/main/java/org/reflections/vfs/JarInputDir.java
+++ b/src/main/java/org/reflections/vfs/JarInputDir.java
@@ -27,16 +27,8 @@ public class JarInputDir implements Vfs.Dir {
     public Iterable<Vfs.File> getFiles() {
         return () -> new Iterator<Vfs.File>() {
             {
-                try {
-                    InputStream stream = url.openConnection().getInputStream();
-                    if (stream instanceof JarInputStream) {
-                        jarInputStream = (JarInputStream) stream;
-                    } else {
-                        jarInputStream = new JarInputStream(stream);
-                    }
-                } catch (Exception e) {
-                    throw new ReflectionsException("Could not open url connection", e);
-                }
+                try { jarInputStream = new JarInputStream(url.openConnection().getInputStream()); }
+                catch (Exception e) { throw new ReflectionsException("Could not open url connection", e); }
             }
 
             Vfs.File entry = null;

--- a/src/main/java/org/reflections/vfs/JarInputDir.java
+++ b/src/main/java/org/reflections/vfs/JarInputDir.java
@@ -27,8 +27,16 @@ public class JarInputDir implements Vfs.Dir {
     public Iterable<Vfs.File> getFiles() {
         return () -> new Iterator<Vfs.File>() {
             {
-                try { jarInputStream = new JarInputStream(url.openConnection().getInputStream()); }
-                catch (Exception e) { throw new ReflectionsException("Could not open url connection", e); }
+                try {
+                    InputStream stream = url.openConnection().getInputStream();
+                    if (stream instanceof JarInputStream) {
+                        jarInputStream = (JarInputStream) stream;
+                    } else {
+                        jarInputStream = new JarInputStream(stream);
+                    }
+                } catch (Exception e) {
+                    throw new ReflectionsException("Could not open url connection", e);
+                }
             }
 
             Vfs.File entry = null;

--- a/src/main/java/org/reflections/vfs/JbossDir.java
+++ b/src/main/java/org/reflections/vfs/JbossDir.java
@@ -1,12 +1,13 @@
 package org.reflections.vfs;
 
 import org.jboss.vfs.VirtualFile;
+import org.jboss.vfs.VirtualJarInputStream;
 
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Stack;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
 
 public class JbossDir implements Vfs.Dir {
 
@@ -18,8 +19,10 @@ public class JbossDir implements Vfs.Dir {
 
     public static Vfs.Dir createDir(URL url) throws Exception {
         Object content = url.openConnection().getContent();
-        if (content instanceof JarInputStream) {
-            return new JarInputDir(url);
+        if (content instanceof VirtualJarInputStream) {
+            Field root = content.getClass().getDeclaredField("root");
+            root.setAccessible(true);
+            content = root.get(content);
         }
         VirtualFile virtualFile = (VirtualFile) content;
         if (virtualFile.isFile()) {

--- a/src/main/java/org/reflections/vfs/JbossDir.java
+++ b/src/main/java/org/reflections/vfs/JbossDir.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.Stack;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 
 public class JbossDir implements Vfs.Dir {
 
@@ -16,8 +17,12 @@ public class JbossDir implements Vfs.Dir {
     }
 
     public static Vfs.Dir createDir(URL url) throws Exception {
-        VirtualFile virtualFile = (VirtualFile) url.openConnection().getContent();
-        if(virtualFile.isFile()) {
+        Object content = url.openConnection().getContent();
+        if (content instanceof JarInputStream) {
+            return new JarInputDir(url);
+        }
+        VirtualFile virtualFile = (VirtualFile) content;
+        if (virtualFile.isFile()) {
             return new ZipDir(new JarFile(virtualFile.getPhysicalFile()));
         }
         return new JbossDir(virtualFile);


### PR DESCRIPTION
With Java Zulu 17.0.3 `url.openConnection().getContent()` returns a `VirtualJarInputStream` which would lead to a ClassCastException