### PR TITLE
Make scanning logs optional

### DIFF
--- a/src/main/java/org/reflections/Configuration.java
+++ b/src/main/java/org/reflections/Configuration.java
@@ -30,4 +30,9 @@ public interface Configuration {
     /** if true (default), expand super types after scanning, for super types that were not scanned.
      * <p>see {@link Reflections#expandSuperTypes(Map, Map)}*/
     boolean shouldExpandSuperTypes();
+
+    /** if true (default), log the scanning process.
+     * @return true if logging is enabled, false otherwise
+     */
+    boolean shouldLog();
 }

--- a/src/main/java/org/reflections/Reflections.java
+++ b/src/main/java/org/reflections/Reflections.java
@@ -186,13 +186,13 @@ public class Reflections implements NameHelper {
                                     if (entries != null) collect.get(scanner.index()).addAll(entries);
                                 }
                             } catch (Exception e) {
-                                if (log != null) log.debug("could not scan file {} with scanner {}", file.getRelativePath(), scanner.getClass().getSimpleName(), e);
+                                if (log != null && configuration.shouldLog()) log.debug("could not scan file {} with scanner {}", file.getRelativePath(), scanner.getClass().getSimpleName(), e);
                             }
                         }
                     }
                 }
             } catch (Exception e) {
-                if (log != null) log.warn("could not create Vfs.Dir from url. ignoring the exception and continuing", e);
+                if (log != null && configuration.shouldLog()) log.warn("could not create Vfs.Dir from url. ignoring the exception and continuing", e);
             }
         });
 
@@ -206,7 +206,7 @@ public class Reflections implements NameHelper {
                             Map.Entry::getKey,
                             HashMap::new,
                             Collectors.mapping(Map.Entry::getValue, Collectors.toSet())))));
-        if (log != null) {
+        if (log != null && configuration.shouldLog()) {
             int keys = 0, values = 0;
             for (Map<String, Set<String>> map : storeMap.values()) {
                 keys += map.size();

--- a/src/main/java/org/reflections/util/ConfigurationBuilder.java
+++ b/src/main/java/org/reflections/util/ConfigurationBuilder.java
@@ -43,6 +43,7 @@ public class ConfigurationBuilder implements Configuration {
     private boolean isParallel = true;
     private ClassLoader[] classLoaders;
     private boolean expandSuperTypes = true;
+    private boolean shouldLog = true;
 
     public ConfigurationBuilder() {
         urls = new HashSet<>();
@@ -232,10 +233,20 @@ public class ConfigurationBuilder implements Configuration {
         return expandSuperTypes;
     }
 
+    @Override
+    public boolean shouldLog() {
+        return shouldLog;
+    }
+
     /** if set to true, Reflections will expand super types after scanning.
      * <p>see {@link org.reflections.Reflections#expandSuperTypes(Map, Map)} */
     public ConfigurationBuilder setExpandSuperTypes(boolean expandSuperTypes) {
         this.expandSuperTypes = expandSuperTypes;
+        return this;
+    }
+
+    public ConfigurationBuilder disableLogging() {
+        this.shouldLog = false;
         return this;
     }
 }


### PR DESCRIPTION
Even though logs are fine in some cases, it's always nice to have the option to disable them, as sometimes they can be more annoying than helpful or maybe people just want to have minimal logs